### PR TITLE
ci: skip deploy for copilot/* pushes

### DIFF
--- a/.github/workflows/deploy-to-ecs.yml
+++ b/.github/workflows/deploy-to-ecs.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - master
-      - copilot/**
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Remove copilot/** from workflow triggers so pushes to copilot/* won't start ECS deploy; keep deploy on main/master.