### PR TITLE
Add dotenv support for local development environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Gemini API Configuration
+GEMINI_API_KEY=your_gemini_api_key_here
+
+# LangChain Configuration
+LANGCHAIN_API_KEY=your_langchain_api_key_here
+
+# Supabase Configuration
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_ANON_KEY=your_supabase_anon_key_here
+
+# Server Configuration
+PORT=3000

--- a/README.md
+++ b/README.md
@@ -229,6 +229,26 @@ aws ecs describe-tasks \
 
 ## 🛠️ ローカル開発
 
+### 環境変数の設定
+
+ローカル開発では `.env` ファイルから環境変数を読み込みます。
+
+1. `.env.example` をコピーして `.env` ファイルを作成：
+   ```bash
+   cp .env.example .env
+   ```
+
+2. `.env` ファイルを編集して、実際のAPIキーなどを設定：
+   ```bash
+   GEMINI_API_KEY=your_actual_gemini_api_key
+   LANGCHAIN_API_KEY=your_actual_langchain_api_key
+   SUPABASE_URL=https://your-project.supabase.co
+   SUPABASE_ANON_KEY=your_actual_supabase_anon_key
+   PORT=3000
+   ```
+
+3. **注意**: `.env` ファイルは `.gitignore` に含まれており、Gitにコミットされません。機密情報を含むため、絶対にリポジトリに含めないでください。
+
 ### Docker Compose で実行
 
 ```bash
@@ -241,7 +261,9 @@ docker-compose up --build
 
 ```bash
 npm install
-npm start
+npm run dev    # 開発モード（.envファイルを自動読み込み）
+# または
+npm start      # 本番モード
 ```
 
 ## 📝 ファイル構成

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "1.0.0",
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
+        "dotenv": "^17.2.3",
         "express": "^4.18.2"
       },
       "devDependencies": {
         "@playwright/test": "^1.57.0",
+        "@types/dotenv": "^6.1.1",
         "@types/express": "^5.0.5",
         "@types/jest": "^30.0.0",
         "@types/node": "^24.10.1",
@@ -1344,6 +1346,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/dotenv": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-6.1.1.tgz",
+      "integrity": "sha512-ftQl3DtBvqHl9L16tpqqzA4YzCSXZfi7g8cQceTz5rOlYtk/IZbFjAv3mLOQlNIgOaylCQWQoBdDQHPgEBJPHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/express": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.5.tgz",
@@ -2610,6 +2622,18 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -16,10 +16,12 @@
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
+    "dotenv": "^17.2.3",
     "express": "^4.18.2"
   },
   "devDependencies": {
     "@playwright/test": "^1.57.0",
+    "@types/dotenv": "^6.1.1",
     "@types/express": "^5.0.5",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.10.1",

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -1,4 +1,13 @@
 import { Config } from '../interfaces';
+import dotenv from 'dotenv';
+import path from 'path';
+
+// Load environment variables from .env file in local development
+if (process.env.NODE_ENV !== 'production') {
+  const envPath = path.resolve(process.cwd(), '.env');
+  dotenv.config({ path: envPath, override: true });
+  console.log('Environment variables loaded from .env file');
+}
 
 function getEnvVar(key: string): string {
   const value = process.env[key];


### PR DESCRIPTION
- Install dotenv package and @types/dotenv
- Update config.ts to load .env file in non-production environments
- Add .env.example with required environment variables template
- Update README.md with environment variable setup instructions
- Set override: true to ensure .env values take precedence

Fixes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)