### PR TITLE
feat: #70 注文ステータス確認エージェントの実装

### DIFF
--- a/src/agent/order-status/controller.ts
+++ b/src/agent/order-status/controller.ts
@@ -1,0 +1,24 @@
+import { Request, Response } from 'express';
+import { OrderStatusService } from './service';
+
+const service = new OrderStatusService();
+
+export const chat = async (req: Request, res: Response): Promise<void> => {
+  const { message } = req.body as { message?: string };
+  if (!message || message.trim() === '') {
+    res.status(400).json({ error: 'MISSING_MESSAGE', message: 'messageは必須です' });
+    return;
+  }
+
+  try {
+    const result = await service.runAgent(message.trim());
+    res.json(result);
+  } catch (err) {
+    console.error('OrderStatusAgent error:', err);
+    res.status(502).json({ error: 'GEMINI_ERROR', message: 'Gemini API呼び出しに失敗しました' });
+  }
+};
+
+export const health = (_req: Request, res: Response): void => {
+  res.json({ status: 'ok', feature: 'order-status-agent' });
+};

--- a/src/agent/order-status/router.ts
+++ b/src/agent/order-status/router.ts
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import rateLimit from 'express-rate-limit';
+import { chat, health } from './controller';
+
+const router = Router();
+
+const limiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 20,
+  message: { error: 'RATE_LIMIT', message: 'リクエスト上限に達しました。1分後に再試行してください。' },
+});
+
+router.post('/chat', limiter, chat);
+router.get('/health', health);
+
+export default router;

--- a/src/agent/order-status/service.ts
+++ b/src/agent/order-status/service.ts
@@ -1,0 +1,107 @@
+import { GoogleGenerativeAI, SchemaType, Tool } from '@google/generative-ai';
+import { config } from '../../shared/config';
+import { OrderStatusAgentResponse, OrderStatusToolCall, OrderStatusToolName } from '../../interfaces/agent-order-status';
+
+interface OrderRecord {
+  status: string;
+  estimatedDelivery: string | null;
+}
+
+const ORDER_DATA: Record<string, OrderRecord> = {
+  'ORD-001': { status: '配送中', estimatedDelivery: '2025-12-25' },
+  'ORD-002': { status: '処理中', estimatedDelivery: '2025-12-28' },
+  'ORD-003': { status: '配送完了', estimatedDelivery: '2025-12-20' },
+  'ORD-004': { status: 'キャンセル', estimatedDelivery: null },
+  'ORD-005': { status: '注文受付', estimatedDelivery: '2025-12-30' },
+};
+
+const tools: Tool[] = [
+  {
+    functionDeclarations: [
+      {
+        name: 'get_order_status',
+        description: '注文IDから現在のステータスを取得する',
+        parameters: {
+          type: SchemaType.OBJECT,
+          properties: {
+            orderId: { type: SchemaType.STRING, description: '注文ID（例: ORD-001）' },
+          },
+          required: ['orderId'],
+        },
+      },
+      {
+        name: 'get_estimated_delivery',
+        description: '注文IDから配送予定日を取得する',
+        parameters: {
+          type: SchemaType.OBJECT,
+          properties: {
+            orderId: { type: SchemaType.STRING, description: '注文ID（例: ORD-001）' },
+          },
+          required: ['orderId'],
+        },
+      },
+    ],
+  },
+];
+
+export class OrderStatusService {
+  private genAI: GoogleGenerativeAI;
+
+  constructor() {
+    this.genAI = new GoogleGenerativeAI(config.gemini.apiKey);
+  }
+
+  async runAgent(message: string): Promise<OrderStatusAgentResponse> {
+    const model = this.genAI.getGenerativeModel({
+      model: 'gemini-flash-latest',
+      tools,
+    });
+
+    const chat = model.startChat();
+    const toolCalls: OrderStatusToolCall[] = [];
+
+    let response = await chat.sendMessage(message);
+    let maxLoop = 10;
+
+    while (maxLoop-- > 0) {
+      const candidate = response.response.candidates?.[0];
+      if (!candidate) break;
+
+      const part = candidate.content.parts[0];
+      if (!part.functionCall) break;
+
+      const { name, args } = part.functionCall;
+      const result = this.callTool(name as OrderStatusToolName, args as Record<string, unknown>);
+
+      toolCalls.push({ name, args: args as Record<string, unknown>, result });
+
+      response = await chat.sendMessage([
+        {
+          functionResponse: {
+            name,
+            response: { result },
+          },
+        },
+      ]);
+    }
+
+    const reply = response.response.text();
+    return { reply, toolCalls };
+  }
+
+  callTool(name: OrderStatusToolName, args: Record<string, unknown>): string {
+    const orderId = args['orderId'] as string;
+    const order = ORDER_DATA[orderId];
+
+    switch (name) {
+      case 'get_order_status':
+        if (!order) return `注文ID ${orderId} は見つかりません`;
+        return order.status;
+      case 'get_estimated_delivery':
+        if (!order) return `注文ID ${orderId} は見つかりません`;
+        return order.estimatedDelivery ?? '配送予定日なし（キャンセル済み）';
+      default:
+        return 'Unknown tool';
+    }
+  }
+}

--- a/src/agent/order-status/tests/service.test.ts
+++ b/src/agent/order-status/tests/service.test.ts
@@ -1,0 +1,100 @@
+import { OrderStatusService } from '../service';
+
+jest.mock('@google/generative-ai', () => {
+  const MockGoogleGenerativeAI = jest.fn(() => ({
+    getGenerativeModel: jest.fn(() => ({
+      startChat: jest.fn(() => ({ sendMessage: jest.fn() })),
+    })),
+  }));
+  return {
+    GoogleGenerativeAI: MockGoogleGenerativeAI,
+    SchemaType: { OBJECT: 'object', STRING: 'string' },
+  };
+});
+
+jest.mock('../../../shared/config', () => ({
+  config: { gemini: { apiKey: 'test-key' } },
+}));
+
+describe('OrderStatusService', () => {
+  let service: OrderStatusService;
+
+  beforeEach(() => {
+    service = new OrderStatusService();
+  });
+
+  describe('callTool', () => {
+    it('get_order_status: 既存注文のステータスを返す', () => {
+      expect(service.callTool('get_order_status', { orderId: 'ORD-001' })).toBe('配送中');
+    });
+
+    it('get_order_status: 存在しない注文はエラーメッセージを返す', () => {
+      const result = service.callTool('get_order_status', { orderId: 'ORD-999' });
+      expect(result).toContain('見つかりません');
+    });
+
+    it('get_estimated_delivery: 配送予定日を返す', () => {
+      expect(service.callTool('get_estimated_delivery', { orderId: 'ORD-002' })).toBe('2025-12-28');
+    });
+
+    it('get_estimated_delivery: キャンセル注文は予定日なしを返す', () => {
+      const result = service.callTool('get_estimated_delivery', { orderId: 'ORD-004' });
+      expect(result).toContain('キャンセル');
+    });
+
+    it('get_estimated_delivery: 存在しない注文はエラーメッセージを返す', () => {
+      const result = service.callTool('get_estimated_delivery', { orderId: 'ORD-999' });
+      expect(result).toContain('見つかりません');
+    });
+  });
+
+  describe('runAgent', () => {
+    it('ツールなしで最終回答を返す', async () => {
+      const { GoogleGenerativeAI } = jest.requireMock('@google/generative-ai');
+      GoogleGenerativeAI.mockImplementation(() => ({
+        getGenerativeModel: () => ({
+          startChat: () => ({
+            sendMessage: jest.fn().mockResolvedValue({
+              response: {
+                candidates: [{ content: { parts: [{ text: '回答です' }] } }],
+                text: () => '回答です',
+              },
+            }),
+          }),
+        }),
+      }));
+
+      const svc = new OrderStatusService();
+      const result = await svc.runAgent('ORD-001の状況は？');
+      expect(result.reply).toBe('回答です');
+      expect(result.toolCalls).toHaveLength(0);
+    });
+
+    it('ツール呼び出し後に最終回答を返す', async () => {
+      const { GoogleGenerativeAI } = jest.requireMock('@google/generative-ai');
+      const mockSendMessage = jest.fn()
+        .mockResolvedValueOnce({
+          response: {
+            candidates: [{ content: { parts: [{ functionCall: { name: 'get_order_status', args: { orderId: 'ORD-001' } } }] } }],
+            text: () => '',
+          },
+        })
+        .mockResolvedValueOnce({
+          response: {
+            candidates: [{ content: { parts: [{ text: '配送中です' }] } }],
+            text: () => '配送中です',
+          },
+        });
+
+      GoogleGenerativeAI.mockImplementation(() => ({
+        getGenerativeModel: () => ({ startChat: () => ({ sendMessage: mockSendMessage }) }),
+      }));
+
+      const svc = new OrderStatusService();
+      const result = await svc.runAgent('ORD-001の状況は？');
+      expect(result.reply).toBe('配送中です');
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls[0].name).toBe('get_order_status');
+    });
+  });
+});

--- a/src/agent/order-status/views/order-status-agent.html
+++ b/src/agent/order-status/views/order-status-agent.html
@@ -1,0 +1,256 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>注文ステータス確認エージェント</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      line-height: 1.6;
+      color: #333;
+      background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%);
+      min-height: 100vh;
+      padding: 20px;
+    }
+
+    .container {
+      background: white;
+      border-radius: 12px;
+      box-shadow: 0 10px 40px rgba(0,0,0,0.2);
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 40px;
+    }
+
+    .header-links {
+      display: flex;
+      gap: 12px;
+      margin-bottom: 24px;
+      flex-wrap: wrap;
+    }
+    .header-links a {
+      font-size: 0.85rem;
+      color: #4facfe;
+      text-decoration: none;
+      padding: 4px 10px;
+      border: 1px solid #4facfe;
+      border-radius: 4px;
+    }
+    .header-links a:hover { background: #4facfe; color: white; }
+
+    h1 { color: #4facfe; font-size: 2rem; margin-bottom: 8px; }
+    .subtitle { color: #666; margin-bottom: 24px; }
+
+    .orders-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-bottom: 24px;
+      font-size: 0.9rem;
+    }
+    .orders-table th {
+      background: #4facfe;
+      color: white;
+      padding: 8px 12px;
+      text-align: left;
+    }
+    .orders-table td { padding: 8px 12px; border-bottom: 1px solid #eee; }
+    .orders-table tr:hover td { background: #f0f8ff; }
+
+    .status-badge {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: 10px;
+      font-size: 0.8rem;
+      font-weight: 600;
+    }
+    .status-配送中 { background: #d1ecf1; color: #0c5460; }
+    .status-処理中 { background: #fff3cd; color: #856404; }
+    .status-配送完了 { background: #d4edda; color: #155724; }
+    .status-キャンセル { background: #f8d7da; color: #721c24; }
+    .status-注文受付 { background: #e2e3e5; color: #383d41; }
+
+    .order-ids {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-bottom: 20px;
+    }
+    .order-btn {
+      background: #f0f8ff;
+      border: 1px solid #4facfe;
+      color: #4facfe;
+      padding: 6px 12px;
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 0.85rem;
+    }
+    .order-btn:hover { background: #4facfe; color: white; }
+
+    .input-area {
+      display: flex;
+      gap: 8px;
+      margin-bottom: 24px;
+    }
+    input[type="text"] {
+      flex: 1;
+      padding: 10px 14px;
+      border: 2px solid #ddd;
+      border-radius: 8px;
+      font-size: 0.95rem;
+    }
+    input[type="text"]:focus { outline: none; border-color: #4facfe; }
+    button.send-btn {
+      background: #4facfe;
+      color: white;
+      border: none;
+      padding: 10px 24px;
+      border-radius: 8px;
+      cursor: pointer;
+      font-weight: 600;
+    }
+    button.send-btn:hover { background: #3a9fed; }
+    button.send-btn:disabled { background: #ccc; cursor: not-allowed; }
+
+    .result { display: none; }
+    .tool-log {
+      background: #f8f8f8;
+      border-radius: 8px;
+      padding: 16px;
+      margin-bottom: 16px;
+    }
+    .tool-log h3 { font-size: 0.85rem; color: #999; margin-bottom: 8px; }
+    .tool-entry {
+      font-family: monospace;
+      font-size: 0.85rem;
+      color: #555;
+      margin-bottom: 4px;
+    }
+    .tool-name { color: #4facfe; font-weight: 600; }
+
+    .answer-box {
+      background: #f0f8ff;
+      border-left: 4px solid #4facfe;
+      padding: 16px;
+      border-radius: 0 8px 8px 0;
+    }
+    .answer-box p { white-space: pre-wrap; }
+    .loading { color: #999; font-style: italic; }
+    .error-msg { color: #dc3545; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header-links">
+      <a href="/">← Back to Home</a>
+      <a href="https://github.com/RYA234/typescript-container/issues/70" target="_blank">GitHub Source #70</a>
+      <a href="https://github.com/RYA234/typescript-container/blob/main/.github/docs/features/agent/03-order-status/external-design.md" target="_blank">設計書</a>
+    </div>
+
+    <h1>注文ステータス確認エージェント</h1>
+    <p class="subtitle">Gemini Function Calling を使って注文IDから配送状況・予定日を自然言語で確認できます</p>
+
+    <table class="orders-table">
+      <thead>
+        <tr><th>注文ID</th><th>ステータス</th><th>配送予定日</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>ORD-001</td><td><span class="status-badge status-配送中">配送中</span></td><td>2025-12-25</td></tr>
+        <tr><td>ORD-002</td><td><span class="status-badge status-処理中">処理中</span></td><td>2025-12-28</td></tr>
+        <tr><td>ORD-003</td><td><span class="status-badge status-配送完了">配送完了</span></td><td>2025-12-20</td></tr>
+        <tr><td>ORD-004</td><td><span class="status-badge status-キャンセル">キャンセル</span></td><td>-</td></tr>
+        <tr><td>ORD-005</td><td><span class="status-badge status-注文受付">注文受付</span></td><td>2025-12-30</td></tr>
+      </tbody>
+    </table>
+
+    <div class="order-ids">
+      <button class="order-btn" onclick="setExample('注文 ORD-001 の状況を教えてください')">ORD-001</button>
+      <button class="order-btn" onclick="setExample('ORD-002 はいつ届きますか？')">ORD-002</button>
+      <button class="order-btn" onclick="setExample('ORD-003 の配送は完了していますか？')">ORD-003</button>
+      <button class="order-btn" onclick="setExample('ORD-004 の状況と配送予定日を教えてください')">ORD-004</button>
+      <button class="order-btn" onclick="setExample('ORD-005 はいつ届きますか？')">ORD-005</button>
+    </div>
+
+    <div class="input-area">
+      <input type="text" id="messageInput" placeholder="注文について質問してください..." />
+      <button class="send-btn" id="sendBtn" onclick="sendMessage()">送信する</button>
+    </div>
+
+    <div class="result" id="result">
+      <div class="tool-log" id="toolLog" style="display:none">
+        <h3>🔧 ツール呼び出しログ</h3>
+        <div id="toolEntries"></div>
+      </div>
+      <div class="answer-box">
+        <p id="answerText"></p>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    function setExample(text) {
+      document.getElementById('messageInput').value = text;
+      document.getElementById('messageInput').focus();
+    }
+
+    document.getElementById('messageInput').addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') sendMessage();
+    });
+
+    async function sendMessage() {
+      const input = document.getElementById('messageInput');
+      const message = input.value.trim();
+      if (!message) return;
+
+      const sendBtn = document.getElementById('sendBtn');
+      const result = document.getElementById('result');
+      const answerText = document.getElementById('answerText');
+      const toolLog = document.getElementById('toolLog');
+      const toolEntries = document.getElementById('toolEntries');
+
+      sendBtn.disabled = true;
+      result.style.display = 'block';
+      toolLog.style.display = 'none';
+      toolEntries.innerHTML = '';
+      answerText.textContent = '確認中...';
+      answerText.className = 'loading';
+
+      try {
+        const res = await fetch('/node/agent/order-status/chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ message }),
+        });
+
+        const data = await res.json();
+
+        if (!res.ok) {
+          answerText.textContent = data.message || 'エラーが発生しました';
+          answerText.className = 'error-msg';
+          return;
+        }
+
+        if (data.toolCalls && data.toolCalls.length > 0) {
+          toolLog.style.display = 'block';
+          data.toolCalls.forEach((tool, i) => {
+            const entry = document.createElement('div');
+            entry.className = 'tool-entry';
+            entry.innerHTML = `[${i + 1}] <span class="tool-name">${tool.name}</span>(${JSON.stringify(tool.args)}) → "${tool.result}"`;
+            toolEntries.appendChild(entry);
+          });
+        }
+
+        answerText.textContent = data.reply;
+        answerText.className = '';
+      } catch {
+        answerText.textContent = 'ネットワークエラーが発生しました';
+        answerText.className = 'error-msg';
+      } finally {
+        sendBtn.disabled = false;
+      }
+    }
+  </script>
+</body>
+</html>

--- a/src/agent/router.ts
+++ b/src/agent/router.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from 'express';
 import { placeholderHtml } from '../shared/placeholder';
 import basicAgentRouter from './basic/router';
 import inventoryAgentRouter from './inventory/router';
+import orderStatusRouter from './order-status/router';
 import path from 'path';
 
 const router = Router();
@@ -21,7 +22,11 @@ router.get('/inventory', (_req: Request, res: Response) => {
   res.sendFile(path.join(__dirname, 'inventory', 'views', 'inventory-agent.html'));
 });
 router.use('/inventory', inventoryAgentRouter);
-router.get('/order-status', placeholder('注文ステータス確認エージェント'));
+// #70 注文ステータス確認エージェント
+router.get('/order-status', (_req: Request, res: Response) => {
+  res.sendFile(path.join(__dirname, 'order-status', 'views', 'order-status-agent.html'));
+});
+router.use('/order-status', orderStatusRouter);
 router.get('/unit-convert', placeholder('単位変換エージェント'));
 router.get('/calendar', placeholder('カレンダー確認エージェント'));
 router.get('/credit-check', placeholder('与信チェックエージェント'));

--- a/src/index/views/index.html
+++ b/src/index/views/index.html
@@ -119,7 +119,7 @@
     <div class="grid">
       <div class="feature-item"><a href="/node/agent/simple"><span>✅</span> 天気・計算・時刻エージェント <span class="badge level-初級">初級</span></a></div>
       <div class="feature-item"><a href="/node/agent/inventory"><span>✅</span> 在庫確認エージェント <span class="badge level-初級">初級</span></a></div>
-      <div class="feature-item"><a href="/node/agent/order-status" class="todo"><span>❌</span> 注文ステータス確認エージェント <span class="badge level-初級">初級</span></a></div>
+      <div class="feature-item"><a href="/node/agent/order-status"><span>✅</span> 注文ステータス確認エージェント <span class="badge level-初級">初級</span></a></div>
       <div class="feature-item"><a href="/node/agent/unit-convert" class="todo"><span>❌</span> 単位変換エージェント <span class="badge level-初級">初級</span></a></div>
       <div class="feature-item"><a href="/node/agent/calendar" class="todo"><span>❌</span> カレンダー確認エージェント <span class="badge level-初級">初級</span></a></div>
       <div class="feature-item"><a href="/node/agent/credit-check" class="todo"><span>❌</span> 与信チェックエージェント <span class="badge level-中級">中級</span></a></div>

--- a/src/interfaces/agent-order-status.ts
+++ b/src/interfaces/agent-order-status.ts
@@ -1,0 +1,16 @@
+export interface OrderStatusRequest {
+  message: string;
+}
+
+export interface OrderStatusToolCall {
+  name: string;
+  args: Record<string, unknown>;
+  result: string;
+}
+
+export interface OrderStatusAgentResponse {
+  reply: string;
+  toolCalls: OrderStatusToolCall[];
+}
+
+export type OrderStatusToolName = 'get_order_status' | 'get_estimated_delivery';

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -6,3 +6,4 @@ export * from './supabase';
 export * from './rag';
 export * from './agent-basic';
 export * from './agent-inventory';
+export * from './agent-order-status';


### PR DESCRIPTION
## Summary
- Gemini Function Calling を使った注文ステータス確認AIエージェントを実装
- get_order_status / get_estimated_delivery の2ツールで注文状況・配送予定日を自然言語で回答
- ダッシュボードの注文ステータス確認エージェントを ✅ に更新

## Test plan
- [ ] `npm test` で7テスト全通過を確認
- [ ] http://localhost:3000/node/agent/order-status でページ表示を確認
- [ ] 各注文IDボタンをクリックして正常応答を確認
- [ ] ORD-004（キャンセル）の配送予定日が適切に回答されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)