### PR TITLE
feat: #72 カレンダー確認エージェントの実装

### DIFF
--- a/src/agent/calendar/controller.ts
+++ b/src/agent/calendar/controller.ts
@@ -1,0 +1,24 @@
+import { Request, Response } from 'express';
+import { CalendarAgentService } from './service';
+
+const service = new CalendarAgentService();
+
+export const chat = async (req: Request, res: Response): Promise<void> => {
+  const { message } = req.body as { message?: string };
+  if (!message || message.trim() === '') {
+    res.status(400).json({ error: 'MISSING_MESSAGE', message: 'messageは必須です' });
+    return;
+  }
+
+  try {
+    const result = await service.runAgent(message.trim());
+    res.json(result);
+  } catch (err) {
+    console.error('CalendarAgent error:', err);
+    res.status(502).json({ error: 'GEMINI_ERROR', message: 'Gemini API呼び出しに失敗しました' });
+  }
+};
+
+export const health = (_req: Request, res: Response): void => {
+  res.json({ status: 'ok', feature: 'calendar-agent' });
+};

--- a/src/agent/calendar/router.ts
+++ b/src/agent/calendar/router.ts
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import rateLimit from 'express-rate-limit';
+import { chat, health } from './controller';
+
+const router = Router();
+
+const limiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 20,
+  message: { error: 'RATE_LIMIT', message: 'リクエスト上限に達しました。1分後に再試行してください。' },
+});
+
+router.post('/chat', limiter, chat);
+router.get('/health', health);
+
+export default router;

--- a/src/agent/calendar/service.ts
+++ b/src/agent/calendar/service.ts
@@ -1,0 +1,153 @@
+import { GoogleGenerativeAI, SchemaType, Tool } from '@google/generative-ai';
+import { config } from '../../shared/config';
+import { CalendarAgentResponse, CalendarToolCall, CalendarToolName } from '../../interfaces/agent-calendar';
+
+// 日本の祝日（2025年）
+const HOLIDAYS: Record<string, string> = {
+  '2025-01-01': '元日',
+  '2025-01-13': '成人の日',
+  '2025-02-11': '建国記念の日',
+  '2025-02-23': '天皇誕生日',
+  '2025-03-20': '春分の日',
+  '2025-04-29': '昭和の日',
+  '2025-05-03': '憲法記念日',
+  '2025-05-04': 'みどりの日',
+  '2025-05-05': 'こどもの日',
+  '2025-07-21': '海の日',
+  '2025-08-11': '山の日',
+  '2025-09-15': '敬老の日',
+  '2025-09-23': '秋分の日',
+  '2025-10-13': 'スポーツの日',
+  '2025-11-03': '文化の日',
+  '2025-11-23': '勤労感謝の日',
+};
+
+const DAYS = ['日曜日', '月曜日', '火曜日', '水曜日', '木曜日', '金曜日', '土曜日'];
+
+const tools: Tool[] = [
+  {
+    functionDeclarations: [
+      {
+        name: 'get_day_of_week',
+        description: '指定した日付（YYYY-MM-DD）の曜日を返す',
+        parameters: {
+          type: SchemaType.OBJECT,
+          properties: {
+            date: { type: SchemaType.STRING, description: '日付（例: 2025-01-01）' },
+          },
+          required: ['date'],
+        },
+      },
+      {
+        name: 'is_holiday',
+        description: '指定した日付（YYYY-MM-DD）が祝日かどうかを返す',
+        parameters: {
+          type: SchemaType.OBJECT,
+          properties: {
+            date: { type: SchemaType.STRING, description: '日付（例: 2025-01-01）' },
+          },
+          required: ['date'],
+        },
+      },
+      {
+        name: 'calc_business_days',
+        description: '開始日から終了日までの営業日数（土日・祝日を除く）を計算する',
+        parameters: {
+          type: SchemaType.OBJECT,
+          properties: {
+            startDate: { type: SchemaType.STRING, description: '開始日（例: 2025-01-01）' },
+            endDate: { type: SchemaType.STRING, description: '終了日（例: 2025-01-31）' },
+          },
+          required: ['startDate', 'endDate'],
+        },
+      },
+    ],
+  },
+];
+
+export class CalendarAgentService {
+  private genAI: GoogleGenerativeAI;
+
+  constructor() {
+    this.genAI = new GoogleGenerativeAI(config.gemini.apiKey);
+  }
+
+  async runAgent(message: string): Promise<CalendarAgentResponse> {
+    const model = this.genAI.getGenerativeModel({
+      model: 'gemini-flash-latest',
+      tools,
+    });
+
+    const chat = model.startChat();
+    const toolCalls: CalendarToolCall[] = [];
+
+    let response = await chat.sendMessage(message);
+    let maxLoop = 10;
+
+    while (maxLoop-- > 0) {
+      const candidate = response.response.candidates?.[0];
+      if (!candidate) break;
+
+      const part = candidate.content.parts[0];
+      if (!part.functionCall) break;
+
+      const { name, args } = part.functionCall;
+      const result = this.callTool(name as CalendarToolName, args as Record<string, unknown>);
+
+      toolCalls.push({ name, args: args as Record<string, unknown>, result });
+
+      response = await chat.sendMessage([
+        {
+          functionResponse: {
+            name,
+            response: { result },
+          },
+        },
+      ]);
+    }
+
+    const reply = response.response.text();
+    return { reply, toolCalls };
+  }
+
+  callTool(name: CalendarToolName, args: Record<string, unknown>): string {
+    switch (name) {
+      case 'get_day_of_week':
+        return this.getDayOfWeek(args['date'] as string);
+      case 'is_holiday':
+        return this.isHoliday(args['date'] as string);
+      case 'calc_business_days':
+        return this.calcBusinessDays(args['startDate'] as string, args['endDate'] as string);
+      default:
+        return 'Unknown tool';
+    }
+  }
+
+  getDayOfWeek(date: string): string {
+    const d = new Date(date);
+    if (isNaN(d.getTime())) return '無効な日付です';
+    return DAYS[d.getDay()];
+  }
+
+  isHoliday(date: string): string {
+    return HOLIDAYS[date] ?? '祝日ではありません';
+  }
+
+  calcBusinessDays(startDate: string, endDate: string): string {
+    const start = new Date(startDate);
+    const end = new Date(endDate);
+    if (isNaN(start.getTime()) || isNaN(end.getTime())) return '無効な日付です';
+
+    let count = 0;
+    const current = new Date(start);
+    while (current <= end) {
+      const dateStr = current.toISOString().split('T')[0];
+      const day = current.getDay();
+      if (day !== 0 && day !== 6 && !HOLIDAYS[dateStr]) {
+        count++;
+      }
+      current.setDate(current.getDate() + 1);
+    }
+    return String(count);
+  }
+}

--- a/src/agent/calendar/tests/service.test.ts
+++ b/src/agent/calendar/tests/service.test.ts
@@ -1,0 +1,89 @@
+import { CalendarAgentService } from '../service';
+
+jest.mock('@google/generative-ai', () => {
+  const MockGoogleGenerativeAI = jest.fn(() => ({
+    getGenerativeModel: jest.fn(() => ({
+      startChat: jest.fn(() => ({ sendMessage: jest.fn() })),
+    })),
+  }));
+  return {
+    GoogleGenerativeAI: MockGoogleGenerativeAI,
+    SchemaType: { OBJECT: 'object', STRING: 'string' },
+  };
+});
+
+jest.mock('../../../shared/config', () => ({
+  config: { gemini: { apiKey: 'test-key' } },
+}));
+
+describe('CalendarAgentService', () => {
+  let service: CalendarAgentService;
+
+  beforeEach(() => {
+    service = new CalendarAgentService();
+  });
+
+  describe('getDayOfWeek', () => {
+    it('2025-01-01 は水曜日', () => {
+      expect(service.getDayOfWeek('2025-01-01')).toBe('水曜日');
+    });
+
+    it('2025-01-04 は土曜日', () => {
+      expect(service.getDayOfWeek('2025-01-04')).toBe('土曜日');
+    });
+
+    it('無効な日付はエラーメッセージを返す', () => {
+      expect(service.getDayOfWeek('invalid')).toBe('無効な日付です');
+    });
+  });
+
+  describe('isHoliday', () => {
+    it('2025-01-01 は元日', () => {
+      expect(service.isHoliday('2025-01-01')).toBe('元日');
+    });
+
+    it('2025-01-02 は祝日ではない', () => {
+      expect(service.isHoliday('2025-01-02')).toBe('祝日ではありません');
+    });
+  });
+
+  describe('calcBusinessDays', () => {
+    it('2025-01-01 から 2025-01-10 の営業日数', () => {
+      // 1/1(祝)、1/2(木)、1/3(金)、1/4(土)、1/5(日)、1/6(月)、1/7(火)、1/8(水)、1/9(木)、1/10(金)
+      // 営業日: 1/2, 1/3, 1/6, 1/7, 1/8, 1/9, 1/10 = 7日
+      expect(service.calcBusinessDays('2025-01-01', '2025-01-10')).toBe('7');
+    });
+
+    it('無効な日付はエラーメッセージを返す', () => {
+      expect(service.calcBusinessDays('invalid', '2025-01-10')).toBe('無効な日付です');
+    });
+  });
+
+  describe('runAgent', () => {
+    it('ツール呼び出し後に最終回答を返す', async () => {
+      const { GoogleGenerativeAI } = jest.requireMock('@google/generative-ai');
+      const mockSendMessage = jest.fn()
+        .mockResolvedValueOnce({
+          response: {
+            candidates: [{ content: { parts: [{ functionCall: { name: 'get_day_of_week', args: { date: '2025-01-01' } } }] } }],
+            text: () => '',
+          },
+        })
+        .mockResolvedValueOnce({
+          response: {
+            candidates: [{ content: { parts: [{ text: '2025年1月1日は水曜日です' }] } }],
+            text: () => '2025年1月1日は水曜日です',
+          },
+        });
+
+      GoogleGenerativeAI.mockImplementation(() => ({
+        getGenerativeModel: () => ({ startChat: () => ({ sendMessage: mockSendMessage }) }),
+      }));
+
+      const svc = new CalendarAgentService();
+      const result = await svc.runAgent('2025-01-01は何曜日？');
+      expect(result.reply).toBe('2025年1月1日は水曜日です');
+      expect(result.toolCalls).toHaveLength(1);
+    });
+  });
+});

--- a/src/agent/calendar/views/calendar-agent.html
+++ b/src/agent/calendar/views/calendar-agent.html
@@ -1,0 +1,248 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>カレンダー確認エージェント</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      line-height: 1.6;
+      color: #333;
+      background: linear-gradient(135deg, #43e97b 0%, #38f9d7 100%);
+      min-height: 100vh;
+      padding: 20px;
+    }
+
+    .container {
+      background: white;
+      border-radius: 12px;
+      box-shadow: 0 10px 40px rgba(0,0,0,0.2);
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 40px;
+    }
+
+    .header-links {
+      display: flex;
+      gap: 12px;
+      margin-bottom: 24px;
+      flex-wrap: wrap;
+    }
+    .header-links a {
+      font-size: 0.85rem;
+      color: #38a169;
+      text-decoration: none;
+      padding: 4px 10px;
+      border: 1px solid #38a169;
+      border-radius: 4px;
+    }
+    .header-links a:hover { background: #38a169; color: white; }
+
+    h1 { color: #38a169; font-size: 2rem; margin-bottom: 8px; }
+    .subtitle { color: #666; margin-bottom: 24px; }
+
+    .tools-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 8px;
+      margin-bottom: 24px;
+    }
+    .tool-card {
+      background: #f0fff4;
+      border: 1px solid #9ae6b4;
+      border-radius: 8px;
+      padding: 12px;
+      text-align: center;
+    }
+    .tool-card h3 { font-size: 0.85rem; color: #38a169; margin-bottom: 4px; }
+    .tool-card p { font-size: 0.8rem; color: #666; }
+
+    .examples {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-bottom: 20px;
+    }
+    .example-btn {
+      background: #f0fff4;
+      border: 1px solid #38a169;
+      color: #38a169;
+      padding: 6px 12px;
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 0.85rem;
+    }
+    .example-btn:hover { background: #38a169; color: white; }
+
+    .input-area {
+      display: flex;
+      gap: 8px;
+      margin-bottom: 24px;
+    }
+    input[type="text"] {
+      flex: 1;
+      padding: 10px 14px;
+      border: 2px solid #ddd;
+      border-radius: 8px;
+      font-size: 0.95rem;
+    }
+    input[type="text"]:focus { outline: none; border-color: #38a169; }
+    button.send-btn {
+      background: #38a169;
+      color: white;
+      border: none;
+      padding: 10px 24px;
+      border-radius: 8px;
+      cursor: pointer;
+      font-weight: 600;
+    }
+    button.send-btn:hover { background: #2f855a; }
+    button.send-btn:disabled { background: #ccc; cursor: not-allowed; }
+
+    .result { display: none; }
+    .tool-log {
+      background: #f8f8f8;
+      border-radius: 8px;
+      padding: 16px;
+      margin-bottom: 16px;
+    }
+    .tool-log h3 { font-size: 0.85rem; color: #999; margin-bottom: 8px; }
+    .tool-entry {
+      font-family: monospace;
+      font-size: 0.85rem;
+      color: #555;
+      margin-bottom: 4px;
+    }
+    .tool-name { color: #38a169; font-weight: 600; }
+
+    .answer-box {
+      background: #f0fff4;
+      border-left: 4px solid #38a169;
+      padding: 16px;
+      border-radius: 0 8px 8px 0;
+    }
+    .answer-box p { white-space: pre-wrap; }
+    .loading { color: #999; font-style: italic; }
+    .error-msg { color: #dc3545; }
+
+    .note { font-size: 0.8rem; color: #999; margin-top: 8px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header-links">
+      <a href="/">← Back to Home</a>
+      <a href="https://github.com/RYA234/typescript-container/issues/72" target="_blank">GitHub Source #72</a>
+      <a href="https://github.com/RYA234/typescript-container/blob/main/.github/docs/features/agent/05-calendar/external-design.md" target="_blank">設計書</a>
+    </div>
+
+    <h1>カレンダー確認エージェント</h1>
+    <p class="subtitle">Gemini Function Calling を使って曜日・祝日判定・営業日数を自然言語で確認できます</p>
+
+    <div class="tools-grid">
+      <div class="tool-card">
+        <h3>get_day_of_week</h3>
+        <p>日付から曜日を取得</p>
+      </div>
+      <div class="tool-card">
+        <h3>is_holiday</h3>
+        <p>祝日かどうかを判定</p>
+      </div>
+      <div class="tool-card">
+        <h3>calc_business_days</h3>
+        <p>期間内の営業日数を計算</p>
+      </div>
+    </div>
+
+    <div class="examples">
+      <button class="example-btn" onclick="setExample('2025-01-01は何曜日で祝日ですか？')">2025-01-01は？</button>
+      <button class="example-btn" onclick="setExample('2025-05-03から2025-05-05は祝日ですか？')">GW祝日確認</button>
+      <button class="example-btn" onclick="setExample('2025-01-01から2025-01-31の営業日数は？')">1月の営業日数</button>
+      <button class="example-btn" onclick="setExample('2025-12-25は何曜日？')">2025-12-25</button>
+    </div>
+
+    <div class="input-area">
+      <input type="text" id="messageInput" placeholder="日付について質問してください..." />
+      <button class="send-btn" id="sendBtn" onclick="sendMessage()">送信する</button>
+    </div>
+
+    <div class="result" id="result">
+      <div class="tool-log" id="toolLog" style="display:none">
+        <h3>🔧 ツール呼び出しログ</h3>
+        <div id="toolEntries"></div>
+      </div>
+      <div class="answer-box">
+        <p id="answerText"></p>
+      </div>
+    </div>
+    <p class="note">※ 祝日データは2025年の日本の祝日のみ対応</p>
+  </div>
+
+  <script>
+    function setExample(text) {
+      document.getElementById('messageInput').value = text;
+      document.getElementById('messageInput').focus();
+    }
+
+    document.getElementById('messageInput').addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') sendMessage();
+    });
+
+    async function sendMessage() {
+      const input = document.getElementById('messageInput');
+      const message = input.value.trim();
+      if (!message) return;
+
+      const sendBtn = document.getElementById('sendBtn');
+      const result = document.getElementById('result');
+      const answerText = document.getElementById('answerText');
+      const toolLog = document.getElementById('toolLog');
+      const toolEntries = document.getElementById('toolEntries');
+
+      sendBtn.disabled = true;
+      result.style.display = 'block';
+      toolLog.style.display = 'none';
+      toolEntries.innerHTML = '';
+      answerText.textContent = '確認中...';
+      answerText.className = 'loading';
+
+      try {
+        const res = await fetch('/node/agent/calendar/chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ message }),
+        });
+
+        const data = await res.json();
+
+        if (!res.ok) {
+          answerText.textContent = data.message || 'エラーが発生しました';
+          answerText.className = 'error-msg';
+          return;
+        }
+
+        if (data.toolCalls && data.toolCalls.length > 0) {
+          toolLog.style.display = 'block';
+          data.toolCalls.forEach((tool, i) => {
+            const entry = document.createElement('div');
+            entry.className = 'tool-entry';
+            entry.innerHTML = `[${i + 1}] <span class="tool-name">${tool.name}</span>(${JSON.stringify(tool.args)}) → "${tool.result}"`;
+            toolEntries.appendChild(entry);
+          });
+        }
+
+        answerText.textContent = data.reply;
+        answerText.className = '';
+      } catch {
+        answerText.textContent = 'ネットワークエラーが発生しました';
+        answerText.className = 'error-msg';
+      } finally {
+        sendBtn.disabled = false;
+      }
+    }
+  </script>
+</body>
+</html>

--- a/src/agent/router.ts
+++ b/src/agent/router.ts
@@ -4,6 +4,7 @@ import basicAgentRouter from './basic/router';
 import inventoryAgentRouter from './inventory/router';
 import orderStatusRouter from './order-status/router';
 import unitConvertRouter from './unit-convert/router';
+import calendarRouter from './calendar/router';
 import path from 'path';
 
 const router = Router();
@@ -33,7 +34,11 @@ router.get('/unit-convert', (_req: Request, res: Response) => {
   res.sendFile(path.join(__dirname, 'unit-convert', 'views', 'unit-convert-agent.html'));
 });
 router.use('/unit-convert', unitConvertRouter);
-router.get('/calendar', placeholder('カレンダー確認エージェント'));
+// #72 カレンダー確認エージェント
+router.get('/calendar', (_req: Request, res: Response) => {
+  res.sendFile(path.join(__dirname, 'calendar', 'views', 'calendar-agent.html'));
+});
+router.use('/calendar', calendarRouter);
 router.get('/credit-check', placeholder('与信チェックエージェント'));
 router.get('/estimate', placeholder('見積もり作成エージェント'));
 router.get('/attendance', placeholder('勤怠管理エージェント'));

--- a/src/index/views/index.html
+++ b/src/index/views/index.html
@@ -121,7 +121,7 @@
       <div class="feature-item"><a href="/node/agent/inventory"><span>✅</span> 在庫確認エージェント <span class="badge level-初級">初級</span></a></div>
       <div class="feature-item"><a href="/node/agent/order-status"><span>✅</span> 注文ステータス確認エージェント <span class="badge level-初級">初級</span></a></div>
       <div class="feature-item"><a href="/node/agent/unit-convert"><span>✅</span> 単位変換エージェント <span class="badge level-初級">初級</span></a></div>
-      <div class="feature-item"><a href="/node/agent/calendar" class="todo"><span>❌</span> カレンダー確認エージェント <span class="badge level-初級">初級</span></a></div>
+      <div class="feature-item"><a href="/node/agent/calendar"><span>✅</span> カレンダー確認エージェント <span class="badge level-初級">初級</span></a></div>
       <div class="feature-item"><a href="/node/agent/credit-check" class="todo"><span>❌</span> 与信チェックエージェント <span class="badge level-中級">中級</span></a></div>
       <div class="feature-item"><a href="/node/agent/estimate" class="todo"><span>❌</span> 見積もり作成エージェント <span class="badge level-中級">中級</span></a></div>
       <div class="feature-item"><a href="/node/agent/attendance" class="todo"><span>❌</span> 勤怠管理エージェント <span class="badge level-中級">中級</span></a></div>

--- a/src/interfaces/agent-calendar.ts
+++ b/src/interfaces/agent-calendar.ts
@@ -1,0 +1,16 @@
+export interface CalendarRequest {
+  message: string;
+}
+
+export interface CalendarToolCall {
+  name: string;
+  args: Record<string, unknown>;
+  result: string;
+}
+
+export interface CalendarAgentResponse {
+  reply: string;
+  toolCalls: CalendarToolCall[];
+}
+
+export type CalendarToolName = 'get_day_of_week' | 'is_holiday' | 'calc_business_days';

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -8,3 +8,4 @@ export * from './agent-basic';
 export * from './agent-inventory';
 export * from './agent-order-status';
 export * from './agent-unit-convert';
+export * from './agent-calendar';


### PR DESCRIPTION
## Summary
- Gemini Function Calling を使ったカレンダー確認AIエージェントを実装
- get_day_of_week / is_holiday / calc_business_days の3ツールで曜日・祝日・営業日数を自然言語で回答
- ダッシュボードのカレンダー確認エージェントを ✅ に更新

## Test plan
- [ ] `npm test` で8テスト全通過を確認
- [ ] http://localhost:3000/node/agent/calendar でページ表示を確認
- [ ] 各質問例ボタンをクリックして正常応答を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)