### PR TITLE
feat: #79 LangGraphエージェント実装

### DIFF
--- a/.github/docs/features/agent/12-langgraph/internal-design.md
+++ b/.github/docs/features/agent/12-langgraph/internal-design.md
@@ -1,0 +1,97 @@
+# 内部設計書 - LangGraphエージェント
+
+## 型定義
+
+```typescript
+// src/interfaces/agent-langgraph.ts
+
+export type MessageType = "search" | "calculate" | "answer";
+
+export interface GraphState {
+  messages: string[];
+  messageType?: MessageType;
+  searchResult?: string;
+  calcResult?: string;
+  finalAnswer?: string;
+}
+
+export interface LangGraphRequest {
+  message: string;
+}
+
+export interface GraphResponse {
+  reply: string;
+  graphPath: string[];
+  state: Partial<GraphState>;
+}
+```
+
+## グラフ構築（LangGraph.js）
+
+```typescript
+import { StateGraph, END, START } from "@langchain/langgraph";
+
+function buildGraph(): CompiledGraph {
+  const graph = new StateGraph<GraphState>({
+    channels: {
+      messages:     { value: (a, b) => [...a, ...b], default: () => [] },
+      messageType:  { value: (_, b) => b },
+      searchResult: { value: (_, b) => b },
+      calcResult:   { value: (_, b) => b },
+      finalAnswer:  { value: (_, b) => b },
+    },
+  });
+
+  graph.addNode("classify", classifyNode);
+  graph.addNode("search",   searchNode);
+  graph.addNode("calculate", calcNode);
+  graph.addNode("answer",   answerNode);
+
+  graph.addEdge(START, "classify");
+  graph.addConditionalEdges("classify", routeByType, {
+    search:    "search",
+    calculate: "calculate",
+    answer:    "answer",
+  });
+  graph.addEdge("search",    "answer");
+  graph.addEdge("calculate", "answer");
+  graph.addEdge("answer",    END);
+
+  return graph.compile();
+}
+```
+
+## 各ノードの実装詳細
+
+### classifyNode
+
+Gemini に「このメッセージは検索が必要か、計算が必要か、直接回答できるか？」を問い合わせ。
+返答から `messageType` を設定。
+
+### searchNode
+
+ダミー検索 Map またはキーワードマッチで `searchResult` を設定:
+```typescript
+const SEARCH_DB: Record<string, string> = {
+  "東京": "東京都人口: 約 1,400 万人",
+  "大阪": "大阪府人口: 約 880 万人",
+  // ...
+};
+```
+
+### calcNode
+
+入力メッセージから算術式を抽出して計算し `calcResult` を設定。
+
+### answerNode
+
+classify → search/calculate → answer のコンテキストを元に Gemini で最終回答生成。
+
+## テスト方針
+
+| テスト種別 | 対象 | 確認事項 |
+|-----------|------|---------|
+| Unit | classifyNode | search/calculate/answer の分岐 |
+| Unit | searchNode | キーワードマッチ |
+| Unit | routeByType | 全 3 パターン |
+| Integration | runGraph | フルグラフ実行 + graphPath |

--- a/.github/docs/features/agent/12-langgraph/operation-manual.md
+++ b/.github/docs/features/agent/12-langgraph/operation-manual.md
@@ -1,0 +1,83 @@
+# 運用マニュアル - LangGraphエージェント
+
+## 前提条件
+
+| 項目 | 内容 |
+|------|------|
+| Node.js | v20 以上 |
+| 環境変数 GEMINI_API_KEY | 必須 |
+| 環境変数 LANGCHAIN_API_KEY | オプション（LangSmith トレーシング用） |
+| npm パッケージ | @langchain/langgraph, @langchain/google-genai |
+
+## セットアップ手順
+
+```bash
+npm install @langchain/langgraph @langchain/google-genai
+cp .env.example .env
+# GEMINI_API_KEY を設定
+# LANGCHAIN_API_KEY は任意（LangSmith でトレースしたい場合）
+npm run dev
+```
+
+## curl コマンド例
+
+### 検索フロー
+
+```bash
+curl -X POST http://localhost:3000/node/agent/langgraph/chat \
+  -H "Content-Type: application/json" \
+  -d '{"message": "東京の人口を検索してください"}'
+```
+
+### 計算フロー
+
+```bash
+curl -X POST http://localhost:3000/node/agent/langgraph/chat \
+  -H "Content-Type: application/json" \
+  -d '{"message": "東京と大阪の人口の合計を計算してください"}'
+```
+
+### 直接回答フロー
+
+```bash
+curl -X POST http://localhost:3000/node/agent/langgraph/chat \
+  -H "Content-Type: application/json" \
+  -d '{"message": "日本の首都はどこですか？"}'
+```
+
+## レスポンス例
+
+```json
+{
+  "reply": "東京都の人口は約 1,400 万人です。",
+  "graphPath": ["START", "classify", "search", "answer", "END"],
+  "state": {
+    "messageType": "search",
+    "searchResult": "東京都人口: 約 1,400 万人"
+  }
+}
+```
+
+## グラフパス一覧
+
+| パス | 条件 |
+|------|------|
+| START → classify → search → answer → END | 検索が必要な質問 |
+| START → classify → calculate → answer → END | 計算が必要な質問 |
+| START → classify → answer → END | 直接回答できる質問 |
+
+## よくあるエラーと対処
+
+| エラー | 原因 | 対処 |
+|--------|------|------|
+| 400 Bad Request | message なし | リクエストを確認 |
+| 503 | Gemini API 障害 | リトライ |
+| "LangGraph 構築失敗" | パッケージ未インストール | npm install を実行 |
+
+## LangSmith トレーシング設定（任意）
+
+```bash
+export LANGCHAIN_API_KEY=<your-key>
+export LANGCHAIN_TRACING_V2=true
+export LANGCHAIN_PROJECT=typescript-container
+```

--- a/.github/docs/features/agent/12-langgraph/test-cases.md
+++ b/.github/docs/features/agent/12-langgraph/test-cases.md
@@ -1,0 +1,51 @@
+# テストケース - LangGraphエージェント
+
+## 正常系
+
+| # | 入力 message | 期待 messageType | 期待 graphPath |
+|---|-------------|----------------|---------------|
+| 1 | 「東京の人口は？」 | search | START → classify → search → answer → END |
+| 2 | 「100 × 50 を計算して」 | calculate | START → classify → calculate → answer → END |
+| 3 | 「こんにちは」 | answer | START → classify → answer → END |
+| 4 | 「大阪の人口を検索して計算も」 | search | search → answer パス |
+
+## 境界値
+
+| # | 入力 | 期待動作 |
+|---|------|---------|
+| 5 | 1 文字 "a" | answer パスで直接回答 |
+| 6 | 非常に長いメッセージ（1000 文字） | 正常処理 |
+| 7 | 検索キーワードが複数含まれる | 最初のキーワードで検索 |
+
+## 異常系
+
+| # | 入力 | 期待 HTTP ステータス |
+|---|------|-------------------|
+| 8 | message なし | 400 |
+| 9 | Gemini API 障害（classify） | 503 |
+| 10 | Gemini API 障害（answer） | 503 |
+
+## ユニットテスト: classifyNode
+
+| # | message | 期待 messageType |
+|---|---------|----------------|
+| 11 | "東京の人口を検索して" | "search" |
+| 12 | "123 + 456 を計算" | "calculate" |
+| 13 | "ありがとう" | "answer" |
+
+## ユニットテスト: routeByType
+
+| # | state.messageType | 期待ルーティング先 |
+|---|------------------|----------------|
+| 14 | "search" | "search" ノード |
+| 15 | "calculate" | "calculate" ノード |
+| 16 | "answer" | "answer" ノード |
+| 17 | undefined | "answer" ノード（デフォルト） |
+
+## graphPath 確認
+
+| # | シナリオ | 期待 graphPath |
+|---|---------|---------------|
+| 18 | 検索フロー | ["START", "classify", "search", "answer", "END"] |
+| 19 | 計算フロー | ["START", "classify", "calculate", "answer", "END"] |
+| 20 | 直接回答フロー | ["START", "classify", "answer", "END"] |

--- a/e2e/agent/langgraph.spec.ts
+++ b/e2e/agent/langgraph.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Agent langgraph', () => {
+  test('GET /health - 200を返す', async ({ request }) => {
+    const res = await request.get('/node/agent/langgraph/health');
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe('ok');
+  });
+
+  test('POST /chat - message未指定で400を返す', async ({ request }) => {
+    const res = await request.post('/node/agent/langgraph/chat', { data: {} });
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('MISSING_MESSAGE');
+  });
+
+  test('POST /chat - 空文字で400を返す', async ({ request }) => {
+    const res = await request.post('/node/agent/langgraph/chat', { data: { message: '' } });
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('MISSING_MESSAGE');
+  });
+});

--- a/e2e/demo/agent-langgraph.spec.ts
+++ b/e2e/demo/agent-langgraph.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+import { showCaption, highlightAndClick, highlightElement } from '../helpers';
+
+const BASE = '/node/agent/langgraph';
+
+test.describe('Demo: LangGraphエージェント', () => {
+  test('エージェントUIデモ - 状態グラフによる自動振り分け', async ({ page }) => {
+    test.setTimeout(90000);
+    await page.route(`${BASE}/chat`, async (route) => {
+      const body = route.request().postDataJSON() as { message?: string };
+      if (!body.message || body.message.trim() === '') {
+        await route.fulfill({ status: 400, contentType: 'application/json', body: JSON.stringify({ error: 'MISSING_MESSAGE', message: 'messageは必須です' }) });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          reply: '東京都の人口は約1,400万人（2024年）です。日本最大の都市圏を形成しています。',
+          graphPath: ['classify', 'search', 'answer'],
+          state: { messageType: 'search', searchResult: '東京都人口: 約1,400万人（2024年）' },
+        }),
+      });
+    });
+
+    await page.goto(BASE);
+    await showCaption(page, 'LangGraphエージェントを開きました', 2000);
+
+    await highlightElement(page, '.graph-diagram');
+    await showCaption(page, 'classify → search/calculate/answer の状態遷移グラフ', 2000);
+
+    await showCaption(page, '① 「検索: 東京の人口」をクリックします');
+    await highlightAndClick(page, '.example-btn:first-child');
+    await showCaption(page, '検索クエリがセットされました', 1500);
+
+    await showCaption(page, '② 実行ボタンをクリックしてグラフを動かします');
+    await highlightAndClick(page, '#sendBtn');
+
+    await page.waitForSelector('#result', { state: 'visible', timeout: 15000 });
+    await page.waitForSelector('#answerText:not(.loading)', { timeout: 15000 });
+    await showCaption(page, 'グラフが classify → search → answer を経由して回答しました', 2000);
+
+    await highlightElement(page, '#graphPath');
+    await showCaption(page, '実行されたノードパスが可視化されています', 2000);
+
+    await highlightElement(page, '#answerText');
+    const answer = await page.locator('#answerText').textContent();
+    expect(answer).toContain('東京');
+    await showCaption(page, '状態グラフが検索ノードを経由して回答を生成しました', 2000);
+
+    await showCaption(page, '✅ LangGraphエージェントデモ完了', 2000);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
+        "@langchain/core": "^1.1.41",
+        "@langchain/langgraph": "^1.2.9",
         "@supabase/supabase-js": "^2.86.0",
         "dotenv": "^17.2.3",
         "express": "^4.18.2",
@@ -585,6 +587,12 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cfworker/json-schema": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+      "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
       "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -1577,6 +1585,195 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@langchain/core": {
+      "version": "1.1.41",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.41.tgz",
+      "integrity": "sha512-KdoNEf1YVJ9jnOP+smq4O6teu63tE7GDUryOnZ2lVfooHLrHK/ECUadjOcDSCK/yk/xBw/8nexJ3ZNBMtKnstw==",
+      "license": "MIT",
+      "dependencies": {
+        "@cfworker/json-schema": "^4.0.2",
+        "@standard-schema/spec": "^1.1.0",
+        "ansi-styles": "^5.0.0",
+        "camelcase": "6",
+        "decamelize": "1.2.0",
+        "js-tiktoken": "^1.0.12",
+        "langsmith": ">=0.5.0 <1.0.0",
+        "mustache": "^4.2.0",
+        "p-queue": "^6.6.2",
+        "uuid": "^11.1.0",
+        "zod": "^3.25.76 || ^4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@langchain/core/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@langchain/core/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@langchain/langgraph": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.2.9.tgz",
+      "integrity": "sha512-3c7BtGycHC2v9p6w/Hv8L7kEl1YnZYOQTDJtmAp3knk6JOedO7d2bYP3y0SRyhv5orUEGf/KGvx8ZsB/ideP7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@langchain/langgraph-checkpoint": "^1.0.1",
+        "@langchain/langgraph-sdk": "~1.8.9",
+        "@standard-schema/spec": "1.1.0",
+        "uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.40",
+        "zod": "^3.25.32 || ^4.2.0",
+        "zod-to-json-schema": "^3.x"
+      },
+      "peerDependenciesMeta": {
+        "zod-to-json-schema": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@langchain/langgraph-checkpoint": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.0.1.tgz",
+      "integrity": "sha512-HM0cJLRpIsSlWBQ/xuDC67l52SqZ62Bh2Y61DX+Xorqwoh5e1KxYvfCD7GnSTbWWhjBOutvnR0vPhu4orFkZfw==",
+      "license": "MIT",
+      "dependencies": {
+        "uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.0.1"
+      }
+    },
+    "node_modules/@langchain/langgraph-checkpoint/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@langchain/langgraph-sdk": {
+      "version": "1.8.9",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.8.9.tgz",
+      "integrity": "sha512-vpz90auS4iFTNy2X/CFexOEoeFSvaK+MyI7iSmzYs9gGcfzwRjWUJ4MWsuc5ZNRecLStwho0PExVXRgGOXtcRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15",
+        "p-queue": "^9.0.1",
+        "p-retry": "^7.1.1",
+        "uuid": "^13.0.0"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.16",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19",
+        "svelte": "^4.0.0 || ^5.0.0",
+        "vue": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@langchain/core": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@langchain/langgraph-sdk/node_modules/p-queue": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.1.2.tgz",
+      "integrity": "sha512-ktsDOALzTYTWWF1PbkNVg2rOt+HaOaMWJMUnt7T3qf5tvZ1L8dBW3tObzprBcXNMKkwj+yFSLqHso0x+UFcJXw==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@langchain/langgraph-sdk/node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/@langchain/langgraph/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -1679,6 +1876,12 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.86.0",
@@ -1951,6 +2154,12 @@
         "expect": "^30.0.0",
         "pretty-format": "^30.0.0"
       }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
     },
     "node_modules/@types/methods": {
       "version": "1.1.4",
@@ -2602,6 +2811,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.31",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.31.tgz",
@@ -3079,6 +3308,15 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/dedent": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.0.tgz",
@@ -3390,7 +3628,6 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/execa": {
@@ -4023,6 +4260,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/is-network-error": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.1.tgz",
+      "integrity": "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-number": {
@@ -4797,6 +5046,15 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/js-tiktoken": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.5.1"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4849,6 +5107,53 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/langsmith": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.23.tgz",
+      "integrity": "sha512-dE/M/2Gg2S2R8ygDdkWGJVO3JstijvsNvPXsy9V8WGbpb88Zn8xF/aTjPx4mIy5gIoo02T6FssOgYyLf51Dv1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "p-queue": "6.6.2",
+        "uuid": "10.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "*",
+        "@opentelemetry/exporter-trace-otlp-proto": "*",
+        "@opentelemetry/sdk-trace-base": "*",
+        "openai": "*",
+        "ws": ">=7"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-proto": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/langsmith/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/leven": {
@@ -5086,6 +5391,15 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
@@ -5212,6 +5526,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -5255,6 +5578,55 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/p-retry": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.1.1.tgz",
+      "integrity": "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-network-error": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-try": {
@@ -6512,6 +6884,19 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -6836,6 +7221,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
+    "@langchain/core": "^1.1.41",
+    "@langchain/langgraph": "^1.2.9",
     "@supabase/supabase-js": "^2.86.0",
     "dotenv": "^17.2.3",
     "express": "^4.18.2",

--- a/src/agent/langgraph/controller.ts
+++ b/src/agent/langgraph/controller.ts
@@ -1,0 +1,22 @@
+import { Request, Response } from 'express';
+import { LangGraphService } from './service';
+
+const service = new LangGraphService();
+
+export const health = (_req: Request, res: Response): void => {
+  res.json({ status: 'ok', feature: 'langgraph-agent' });
+};
+
+export const chat = async (req: Request, res: Response): Promise<void> => {
+  const { message } = req.body as { message?: string };
+  if (!message || message.trim() === '') {
+    res.status(400).json({ error: 'MISSING_MESSAGE', message: 'messageは必須です' });
+    return;
+  }
+  try {
+    const result = await service.runGraph(message.trim());
+    res.json(result);
+  } catch {
+    res.status(500).json({ error: 'AGENT_ERROR', message: 'グラフの実行に失敗しました' });
+  }
+};

--- a/src/agent/langgraph/router.ts
+++ b/src/agent/langgraph/router.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import rateLimit from 'express-rate-limit';
+import { chat, health } from './controller';
+
+const router = Router();
+
+const limiter = rateLimit({ windowMs: 60 * 1000, max: 20 });
+
+router.get('/health', health);
+router.post('/chat', limiter, chat);
+
+export default router;

--- a/src/agent/langgraph/service.ts
+++ b/src/agent/langgraph/service.ts
@@ -1,0 +1,137 @@
+import { StateGraph, END, START, Annotation } from '@langchain/langgraph';
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import { config } from '../../shared/config';
+import { GraphResponse, MessageType } from '../../interfaces/agent-langgraph';
+
+const SEARCH_DB: Record<string, string> = {
+  '東京': '東京都人口: 約1,400万人（2024年）',
+  '大阪': '大阪府人口: 約880万人（2024年）',
+  '名古屋': '名古屋市人口: 約230万人（2024年）',
+  '福岡': '福岡市人口: 約165万人（2024年）',
+  '札幌': '札幌市人口: 約197万人（2024年）',
+  '日本': '日本の総人口: 約1億2,400万人（2024年）',
+  'Python': 'Python: 汎用プログラミング言語。データサイエンス・AI分野で広く利用。',
+  'TypeScript': 'TypeScript: MicrosoftによるJavaScriptのスーパーセット。型安全な開発を実現。',
+};
+
+const StateAnnotation = Annotation.Root({
+  messages:     Annotation<string[]>({ reducer: (a, b) => [...a, ...b], default: () => [] }),
+  messageType:  Annotation<MessageType | undefined>({ reducer: (_, b) => b, default: () => undefined }),
+  searchResult: Annotation<string | undefined>({ reducer: (_, b) => b, default: () => undefined }),
+  calcResult:   Annotation<string | undefined>({ reducer: (_, b) => b, default: () => undefined }),
+  finalAnswer:  Annotation<string | undefined>({ reducer: (_, b) => b, default: () => undefined }),
+});
+
+type State = typeof StateAnnotation.State;
+
+export class LangGraphService {
+  private genAI: GoogleGenerativeAI;
+
+  constructor() {
+    this.genAI = new GoogleGenerativeAI(config.gemini.apiKey);
+  }
+
+  private buildGraph() {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const workflow = new StateGraph(StateAnnotation) as any;
+
+    workflow.addNode('classify',  this.classifyNode.bind(this));
+    workflow.addNode('search',    this.searchNode.bind(this));
+    workflow.addNode('calculate', this.calcNode.bind(this));
+    workflow.addNode('answer',    this.answerNode.bind(this));
+
+    workflow.addEdge(START, 'classify');
+    workflow.addConditionalEdges('classify', this.routeByType.bind(this), {
+      search:    'search',
+      calculate: 'calculate',
+      answer:    'answer',
+    });
+    workflow.addEdge('search',    'answer');
+    workflow.addEdge('calculate', 'answer');
+    workflow.addEdge('answer',    END);
+
+    return workflow.compile();
+  }
+
+  private async classifyNode(state: State): Promise<Partial<State>> {
+    const message = state.messages[state.messages.length - 1] ?? '';
+    const model = this.genAI.getGenerativeModel({ model: 'gemini-flash-latest' });
+    const prompt = `次のメッセージを分類してください。「search」「calculate」「answer」のいずれか1単語だけ返してください。
+- search: 都市・人物・技術などの情報検索が必要な質問
+- calculate: 数式や四則演算の計算が必要な質問
+- answer: 検索や計算なしで直接回答できる質問
+
+メッセージ: ${message}`;
+
+    const result = await model.generateContent(prompt);
+    const raw = result.response.text().trim().toLowerCase();
+    const messageType: MessageType = raw.includes('search') ? 'search'
+      : raw.includes('calculate') ? 'calculate'
+      : 'answer';
+
+    return { messageType };
+  }
+
+  routeByType(state: State): string {
+    return state.messageType ?? 'answer';
+  }
+
+  searchNode(state: State): Partial<State> {
+    const message = state.messages[state.messages.length - 1] ?? '';
+    for (const [keyword, value] of Object.entries(SEARCH_DB)) {
+      if (message.includes(keyword)) return { searchResult: value };
+    }
+    return { searchResult: '該当するドキュメントが見つかりませんでした' };
+  }
+
+  calcNode(state: State): Partial<State> {
+    const message = state.messages[state.messages.length - 1] ?? '';
+    const match = message.match(/([\d\s+\-*/().]+)/);
+    if (!match) return { calcResult: '計算式が見つかりませんでした' };
+    const expression = match[1].trim();
+    if (!/^[\d\s+\-*/().]+$/.test(expression)) return { calcResult: '計算できない式です' };
+    try {
+      const result = Function(`"use strict"; return (${expression})`)() as number;
+      if (!isFinite(result)) return { calcResult: 'ゼロ除算または計算不能な式です' };
+      return { calcResult: `${expression} = ${result.toLocaleString()}` };
+    } catch {
+      return { calcResult: '式の計算に失敗しました' };
+    }
+  }
+
+  private async answerNode(state: State): Promise<Partial<State>> {
+    const model = this.genAI.getGenerativeModel({ model: 'gemini-flash-latest' });
+    const message = state.messages[state.messages.length - 1] ?? '';
+    const context = [
+      state.searchResult ? `検索結果: ${state.searchResult}` : '',
+      state.calcResult   ? `計算結果: ${state.calcResult}` : '',
+    ].filter(Boolean).join('\n');
+
+    const prompt = context
+      ? `以下の情報を使って質問に回答してください。\n${context}\n\n質問: ${message}`
+      : message;
+
+    const result = await model.generateContent(prompt);
+    return { finalAnswer: result.response.text() };
+  }
+
+  async runGraph(message: string): Promise<GraphResponse> {
+    const graph = this.buildGraph();
+    const result = await graph.invoke({ messages: [message] }) as State;
+
+    const graphPath = ['classify'];
+    if (result.messageType === 'search')    graphPath.push('search');
+    if (result.messageType === 'calculate') graphPath.push('calculate');
+    graphPath.push('answer');
+
+    return {
+      reply: result.finalAnswer ?? '',
+      graphPath,
+      state: {
+        messageType:  result.messageType,
+        searchResult: result.searchResult,
+        calcResult:   result.calcResult,
+      },
+    };
+  }
+}

--- a/src/agent/langgraph/tests/service.test.ts
+++ b/src/agent/langgraph/tests/service.test.ts
@@ -1,0 +1,121 @@
+import { LangGraphService } from '../service';
+
+const mockInvoke = jest.fn().mockResolvedValue({
+  messages: ['test'],
+  messageType: 'answer',
+  finalAnswer: 'テスト回答',
+  searchResult: undefined,
+  calcResult: undefined,
+});
+
+jest.mock('@langchain/langgraph', () => {
+  const END = '__end__';
+  const START = '__start__';
+  const mockAnnotationFn = (opts: unknown) => opts;
+  const Annotation = Object.assign(mockAnnotationFn, {
+    Root: (channels: unknown) => ({ channels, State: {} }),
+  });
+  const StateGraph = jest.fn().mockImplementation(() => ({
+    addNode: jest.fn().mockReturnThis(),
+    addEdge: jest.fn().mockReturnThis(),
+    addConditionalEdges: jest.fn().mockReturnThis(),
+    compile: jest.fn().mockReturnValue({ invoke: mockInvoke }),
+  }));
+  return { StateGraph, END, START, Annotation };
+});
+
+jest.mock('@google/generative-ai', () => {
+  const MockGoogleGenerativeAI = jest.fn(() => ({
+    getGenerativeModel: jest.fn(() => ({
+      generateContent: jest.fn().mockResolvedValue({
+        response: { text: () => 'answer' },
+      }),
+    })),
+  }));
+  return { GoogleGenerativeAI: MockGoogleGenerativeAI };
+});
+
+jest.mock('../../../shared/config', () => ({
+  config: { gemini: { apiKey: 'test-key' } },
+}));
+
+describe('LangGraphService', () => {
+  let service: LangGraphService;
+
+  beforeEach(() => {
+    service = new LangGraphService();
+  });
+
+  describe('searchNode', () => {
+    it('東京キーワードで人口データを返す', () => {
+      const result = service.searchNode({ messages: ['東京の人口は？'], messageType: undefined, searchResult: undefined, calcResult: undefined, finalAnswer: undefined });
+      expect(result.searchResult).toContain('東京');
+    });
+
+    it('大阪キーワードで人口データを返す', () => {
+      const result = service.searchNode({ messages: ['大阪の人口は？'], messageType: undefined, searchResult: undefined, calcResult: undefined, finalAnswer: undefined });
+      expect(result.searchResult).toContain('大阪');
+    });
+
+    it('マッチしないキーワードはメッセージを返す', () => {
+      const result = service.searchNode({ messages: ['存在しない場所xyz'], messageType: undefined, searchResult: undefined, calcResult: undefined, finalAnswer: undefined });
+      expect(result.searchResult).toContain('見つかりませんでした');
+    });
+  });
+
+  describe('calcNode', () => {
+    it('掛け算を計算する', () => {
+      const result = service.calcNode({ messages: ['100 * 200 を計算して'], messageType: undefined, searchResult: undefined, calcResult: undefined, finalAnswer: undefined });
+      expect(result.calcResult).toContain('20,000');
+    });
+
+    it('足し算を計算する', () => {
+      const result = service.calcNode({ messages: ['100 + 200 + 300'], messageType: undefined, searchResult: undefined, calcResult: undefined, finalAnswer: undefined });
+      expect(result.calcResult).toContain('600');
+    });
+
+    it('算術式がなければメッセージを返す', () => {
+      const result = service.calcNode({ messages: ['おはようございます'], messageType: undefined, searchResult: undefined, calcResult: undefined, finalAnswer: undefined });
+      expect(result.calcResult).toContain('見つかりませんでした');
+    });
+  });
+
+  describe('routeByType', () => {
+    it('search を返す', () => {
+      expect(service.routeByType({ messages: [], messageType: 'search', searchResult: undefined, calcResult: undefined, finalAnswer: undefined })).toBe('search');
+    });
+    it('calculate を返す', () => {
+      expect(service.routeByType({ messages: [], messageType: 'calculate', searchResult: undefined, calcResult: undefined, finalAnswer: undefined })).toBe('calculate');
+    });
+    it('answer を返す', () => {
+      expect(service.routeByType({ messages: [], messageType: 'answer', searchResult: undefined, calcResult: undefined, finalAnswer: undefined })).toBe('answer');
+    });
+    it('undefined の場合は answer にフォールバック', () => {
+      expect(service.routeByType({ messages: [], messageType: undefined, searchResult: undefined, calcResult: undefined, finalAnswer: undefined })).toBe('answer');
+    });
+  });
+
+  describe('runGraph', () => {
+    it('answer タイプでグラフパスを返す', async () => {
+      mockInvoke.mockResolvedValueOnce({ messages: ['test'], messageType: 'answer', finalAnswer: 'テスト回答', searchResult: undefined, calcResult: undefined });
+      const result = await service.runGraph('テストメッセージ');
+      expect(result.reply).toBe('テスト回答');
+      expect(result.graphPath).toContain('classify');
+      expect(result.graphPath).toContain('answer');
+    });
+
+    it('search タイプで search ノードがパスに含まれる', async () => {
+      mockInvoke.mockResolvedValueOnce({ messages: ['test'], messageType: 'search', finalAnswer: '東京の人口は1400万人', searchResult: '東京都人口: 約1,400万人', calcResult: undefined });
+      const result = await service.runGraph('東京の人口は？');
+      expect(result.graphPath).toContain('search');
+      expect(result.state.messageType).toBe('search');
+    });
+
+    it('calculate タイプで calculate ノードがパスに含まれる', async () => {
+      mockInvoke.mockResolvedValueOnce({ messages: ['test'], messageType: 'calculate', finalAnswer: '結果は300', searchResult: undefined, calcResult: '100 + 200 = 300' });
+      const result = await service.runGraph('100 + 200');
+      expect(result.graphPath).toContain('calculate');
+      expect(result.state.calcResult).toContain('300');
+    });
+  });
+});

--- a/src/agent/langgraph/views/langgraph-agent.html
+++ b/src/agent/langgraph/views/langgraph-agent.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>LangGraphエージェント</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      line-height: 1.6;
+      color: #333;
+      background: linear-gradient(135deg, #212121 0%, #424242 100%);
+      min-height: 100vh;
+      padding: 20px;
+    }
+    .container {
+      background: white;
+      border-radius: 12px;
+      box-shadow: 0 10px 40px rgba(0,0,0,0.3);
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 40px;
+    }
+    .header-links { display: flex; gap: 12px; margin-bottom: 24px; flex-wrap: wrap; }
+    .header-links a {
+      font-size: 0.85rem; color: #212121; text-decoration: none;
+      padding: 4px 10px; border: 1px solid #212121; border-radius: 4px;
+    }
+    .header-links a:hover { background: #212121; color: white; }
+    h1 { color: #212121; font-size: 2rem; margin-bottom: 8px; }
+    .subtitle { color: #666; margin-bottom: 24px; }
+    .graph-diagram {
+      background: #f5f5f5; border-radius: 8px; padding: 16px;
+      margin-bottom: 24px; font-family: monospace; font-size: 0.85rem;
+    }
+    .graph-diagram h3 { font-size: 0.85rem; color: #757575; margin-bottom: 10px; font-family: inherit; }
+    .graph-flow { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+    .node {
+      background: #212121; color: white;
+      padding: 4px 12px; border-radius: 4px; font-size: 0.8rem;
+    }
+    .node.cond { background: #616161; }
+    .arrow { color: #9e9e9e; }
+    .examples { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 20px; }
+    .example-btn {
+      background: #f5f5f5; border: 1px solid #212121; color: #212121;
+      padding: 6px 12px; border-radius: 6px; cursor: pointer; font-size: 0.85rem;
+    }
+    .example-btn:hover { background: #212121; color: white; }
+    .input-area { display: flex; gap: 8px; margin-bottom: 24px; }
+    input[type="text"] {
+      flex: 1; padding: 10px 14px; border: 2px solid #ddd;
+      border-radius: 8px; font-size: 0.95rem;
+    }
+    input[type="text"]:focus { outline: none; border-color: #212121; }
+    button.send-btn {
+      background: #212121; color: white; border: none;
+      padding: 10px 24px; border-radius: 8px; cursor: pointer; font-weight: 600;
+    }
+    button.send-btn:hover { background: #000; }
+    button.send-btn:disabled { background: #ccc; cursor: not-allowed; }
+    .result { display: none; }
+    .graph-path { background: #f5f5f5; border-radius: 8px; padding: 12px 16px; margin-bottom: 16px; }
+    .graph-path h3 { font-size: 0.85rem; color: #757575; margin-bottom: 8px; }
+    .path-flow { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+    .path-node {
+      background: #212121; color: white;
+      padding: 3px 10px; border-radius: 4px; font-size: 0.8rem; font-family: monospace;
+    }
+    .path-arrow { color: #9e9e9e; }
+    .answer-box { background: #f5f5f5; border-left: 4px solid #212121; padding: 16px; border-radius: 0 8px 8px 0; }
+    .answer-box p { white-space: pre-wrap; }
+    .loading { color: #999; font-style: italic; }
+    .error-msg { color: #dc3545; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header-links">
+      <a href="/">← Back to Home</a>
+      <a href="https://github.com/RYA234/typescript-container/issues/79" target="_blank">GitHub Source #79</a>
+      <a href="https://github.com/RYA234/typescript-container/blob/main/.github/docs/features/agent/12-langgraph/internal-design.md" target="_blank">内部設計書</a>
+      <a href="https://github.com/RYA234/typescript-container/blob/main/.github/docs/features/agent/12-langgraph/operation-manual.md" target="_blank">運用マニュアル</a>
+    </div>
+
+    <h1>LangGraphエージェント</h1>
+    <p class="subtitle">状態遷移グラフで入力を分類し、検索・計算・直接回答を自動で振り分けます</p>
+
+    <div class="graph-diagram">
+      <h3>グラフ構造</h3>
+      <div class="graph-flow">
+        <span class="node">START</span>
+        <span class="arrow">→</span>
+        <span class="node">classify</span>
+        <span class="arrow">→</span>
+        <span class="node cond">search | calculate | answer</span>
+        <span class="arrow">→</span>
+        <span class="node">answer</span>
+        <span class="arrow">→</span>
+        <span class="node">END</span>
+      </div>
+    </div>
+
+    <div class="examples">
+      <button class="example-btn" onclick="setExample('東京の人口を教えてください')">検索: 東京の人口</button>
+      <button class="example-btn" onclick="setExample('1234 * 567 を計算してください')">計算: 掛け算</button>
+      <button class="example-btn" onclick="setExample('TypeScriptとは何ですか？')">検索: TypeScript</button>
+      <button class="example-btn" onclick="setExample('100 + 200 + 300')">計算: 足し算</button>
+      <button class="example-btn" onclick="setExample('おはようございます')">直接回答</button>
+    </div>
+
+    <div class="input-area">
+      <input type="text" id="messageInput" placeholder="例：東京の人口を教えてください" />
+      <button class="send-btn" id="sendBtn" onclick="sendMessage()">実行</button>
+    </div>
+
+    <div class="result" id="result">
+      <div class="graph-path" id="graphPath" style="display:none">
+        <h3>📊 実行されたグラフパス</h3>
+        <div class="path-flow" id="pathFlow"></div>
+      </div>
+      <div class="answer-box">
+        <p id="answerText"></p>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    function setExample(text) {
+      document.getElementById('messageInput').value = text;
+      document.getElementById('messageInput').focus();
+    }
+    document.getElementById('messageInput').addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') sendMessage();
+    });
+    async function sendMessage() {
+      const input = document.getElementById('messageInput');
+      const message = input.value.trim();
+      if (!message) return;
+      const sendBtn = document.getElementById('sendBtn');
+      const result = document.getElementById('result');
+      const answerText = document.getElementById('answerText');
+      const graphPathEl = document.getElementById('graphPath');
+      const pathFlow = document.getElementById('pathFlow');
+      sendBtn.disabled = true;
+      result.style.display = 'block';
+      graphPathEl.style.display = 'none';
+      pathFlow.innerHTML = '';
+      answerText.textContent = 'グラフ実行中...';
+      answerText.className = 'loading';
+      try {
+        const res = await fetch('/node/agent/langgraph/chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ message }),
+        });
+        const data = await res.json();
+        if (!res.ok) {
+          answerText.textContent = data.message || 'エラーが発生しました';
+          answerText.className = 'error-msg';
+          return;
+        }
+        if (data.graphPath && data.graphPath.length > 0) {
+          graphPathEl.style.display = 'block';
+          data.graphPath.forEach((node, i) => {
+            if (i > 0) {
+              const arrow = document.createElement('span');
+              arrow.className = 'path-arrow';
+              arrow.textContent = '→';
+              pathFlow.appendChild(arrow);
+            }
+            const el = document.createElement('span');
+            el.className = 'path-node';
+            el.textContent = node;
+            pathFlow.appendChild(el);
+          });
+        }
+        answerText.textContent = data.reply;
+        answerText.className = '';
+      } catch {
+        answerText.textContent = 'ネットワークエラーが発生しました';
+        answerText.className = 'error-msg';
+      } finally {
+        sendBtn.disabled = false;
+      }
+    }
+  </script>
+</body>
+</html>

--- a/src/agent/router.ts
+++ b/src/agent/router.ts
@@ -11,6 +11,7 @@ import attendanceRouter from './attendance/router';
 import inquiryRoutingRouter from './inquiry-routing/router';
 import dataAggregationRouter from './data-aggregation/router';
 import ragAgentRouter from './rag-agent/router';
+import langGraphRouter from './langgraph/router';
 import path from 'path';
 
 const router = Router();
@@ -75,7 +76,11 @@ router.get('/rag', (_req: Request, res: Response) => {
   res.sendFile(path.join(__dirname, 'rag-agent', 'views', 'rag-agent.html'));
 });
 router.use('/rag', ragAgentRouter);
-router.get('/langgraph', placeholder('LangGraphエージェント'));
+// #79 LangGraphエージェント
+router.get('/langgraph', (_req: Request, res: Response) => {
+  res.sendFile(path.join(__dirname, 'langgraph', 'views', 'langgraph-agent.html'));
+});
+router.use('/langgraph', langGraphRouter);
 router.get('/research', placeholder('自律リサーチエージェント'));
 router.get('/multi', placeholder('マルチエージェント'));
 router.get('/credit-check-dotnet', placeholder('与信チェック + dotnet連携'));

--- a/src/interfaces/agent-langgraph.ts
+++ b/src/interfaces/agent-langgraph.ts
@@ -1,0 +1,15 @@
+export type MessageType = 'search' | 'calculate' | 'answer';
+
+export interface GraphState {
+  messages: string[];
+  messageType?: MessageType;
+  searchResult?: string;
+  calcResult?: string;
+  finalAnswer?: string;
+}
+
+export interface GraphResponse {
+  reply: string;
+  graphPath: string[];
+  state: Partial<GraphState>;
+}


### PR DESCRIPTION
## Summary
- `@langchain/langgraph` を使って状態遷移グラフで入力を自動振り分けするエージェントを実装
- 4ノード構成: `classify`（Geminiで分類）→ `search` / `calculate` / `answer`（条件分岐）
- 実行されたノードパス（classify → search → answer 等）をUIで可視化
- チャコールグレーテーマ（#212121）のUI実装

## Changes
- `src/interfaces/agent-langgraph.ts` — 型定義
- `src/agent/langgraph/service.ts` — StateGraph + 4ノード実装
- `src/agent/langgraph/controller.ts` / `router.ts` — APIエンドポイント
- `src/agent/langgraph/views/langgraph-agent.html` — UI（グラフ構造図・パス可視化）
- `src/agent/langgraph/tests/service.test.ts` — Jestユニットテスト13件
- `e2e/agent/langgraph.spec.ts` — E2E APIテスト3件
- `e2e/demo/agent-langgraph.spec.ts` — デモ動画用テスト
- `package.json` — @langchain/langgraph @langchain/core 追加

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)