### PR TITLE
feat: #81 マルチエージェント実装

### DIFF
--- a/.github/docs/features/agent/14-multi-agent/internal-design.md
+++ b/.github/docs/features/agent/14-multi-agent/internal-design.md
@@ -1,0 +1,107 @@
+# 内部設計書 - マルチエージェント
+
+## 型定義
+
+```typescript
+// src/interfaces/agent-multi.ts
+
+export interface AgentLogEntry {
+  agent: "Orchestrator" | "ResearchAgent" | "SummaryAgent";
+  action: string;
+  result: string | string[];
+}
+
+export interface ResearchResult {
+  topic: string;
+  content: string;
+}
+
+export interface MultiAgentRequest {
+  message: string;
+}
+
+export interface MultiAgentResponse {
+  reply: string;
+  agentLog: AgentLogEntry[];
+}
+```
+
+## OrchestratorAgent 実装
+
+```typescript
+export class OrchestratorAgent {
+  async decomposeTask(message: string): Promise<string[]> {
+    const prompt = `
+以下のタスクを 2〜4 個のサブタスクに分解してください。
+タスク: "${message}"
+JSON 配列（文字列のリスト）で返してください。
+`;
+    const response = await this.geminiClient.generateContent(prompt);
+    // JSON パース。失敗時はメッセージ全体を 1 タスクとして返す
+    return JSON.parse(response.text);
+  }
+}
+```
+
+## ResearchAgent 実装
+
+```typescript
+export class ResearchAgent {
+  private searchDb: Map<string, string> = new Map([
+    ["TypeScript", "TypeScript は Microsoft 製の静的型付け言語。JavaScript のスーパーセット。"],
+    ["Python", "Python は動的型付けのインタープリタ言語。科学計算・AI 分野で広く使われる。"],
+    ["比較", "TypeScript: 型安全・大規模開発向き。Python: 手軽・AI/ML 向き。"],
+  ]);
+
+  async research(topic: string): Promise<string> {
+    const localResult = [...this.searchDb.entries()]
+      .find(([key]) => topic.includes(key))?.[1] ?? "情報なし";
+    const prompt = `次の情報をもとに "${topic}" について 2〜3 文でまとめてください: ${localResult}`;
+    return await this.geminiClient.generateTextContent(prompt);
+  }
+}
+```
+
+## SummaryAgent 実装
+
+```typescript
+export class SummaryAgent {
+  async summarize(results: ResearchResult[]): Promise<string> {
+    const context = results
+      .map((r) => `【${r.topic}】\n${r.content}`)
+      .join("\n\n");
+    const prompt = `次の調査結果をもとに、わかりやすいレポートを作成してください:\n\n${context}`;
+    return await this.geminiClient.generateTextContent(prompt);
+  }
+}
+```
+
+## MultiAgentService フロー
+
+```typescript
+async run(message: string): Promise<MultiAgentResponse> {
+  const log: AgentLogEntry[] = [];
+  const tasks = await this.orchestrator.decomposeTask(message);
+  log.push({ agent: "Orchestrator", action: "タスク分解", result: tasks });
+
+  const results: ResearchResult[] = [];
+  for (const task of tasks.slice(0, -1)) {  // 最後のタスクは SummaryAgent が担う
+    const content = await this.researchAgent.research(task);
+    results.push({ topic: task, content });
+    log.push({ agent: "ResearchAgent", action: task, result: content });
+  }
+
+  const summary = await this.summaryAgent.summarize(results);
+  log.push({ agent: "SummaryAgent", action: "まとめ", result: summary });
+  return { reply: summary, agentLog: log };
+}
+```
+
+## テスト方針
+
+| テスト種別 | 対象 | 確認事項 |
+|-----------|------|---------|
+| Unit | OrchestratorAgent.decomposeTask | タスク配列の返却 |
+| Unit | ResearchAgent.research | DB ヒット・ミス |
+| Unit | SummaryAgent.summarize | まとめ生成 |
+| Integration | MultiAgentService.run | 全エージェント協調動作 |

--- a/.github/docs/features/agent/14-multi-agent/operation-manual.md
+++ b/.github/docs/features/agent/14-multi-agent/operation-manual.md
@@ -1,0 +1,76 @@
+# 運用マニュアル - マルチエージェント
+
+## 前提条件
+
+| 項目 | 内容 |
+|------|------|
+| Node.js | v20 以上 |
+| 環境変数 GEMINI_API_KEY | 必須 |
+| Gemini API 呼び出し回数 | 1 リクエストで 3〜6 回程度（コスト注意） |
+
+## セットアップ手順
+
+```bash
+npm install
+cp .env.example .env
+# GEMINI_API_KEY を設定
+npm run dev
+```
+
+## curl コマンド例
+
+### 比較レポート生成
+
+```bash
+curl -X POST http://localhost:3000/node/agent/multi-agent/chat \
+  -H "Content-Type: application/json" \
+  -d '{"message": "TypeScript と Python の開発効率を比較したレポートを作成してください"}'
+```
+
+### 技術調査
+
+```bash
+curl -X POST http://localhost:3000/node/agent/multi-agent/chat \
+  -H "Content-Type: application/json" \
+  -d '{"message": "Node.js のメリットとデメリットをまとめてください"}'
+```
+
+### ヘルスチェック
+
+```bash
+curl http://localhost:3000/node/agent/multi-agent/health
+```
+
+## レスポンス例
+
+```json
+{
+  "reply": "TypeScript と Python の比較レポート：...",
+  "agentLog": [
+    { "agent": "Orchestrator", "action": "タスク分解", "result": ["TypeScript 調査", "Python 調査"] },
+    { "agent": "ResearchAgent", "action": "TypeScript 調査", "result": "TypeScript は..." },
+    { "agent": "ResearchAgent", "action": "Python 調査",   "result": "Python は..." },
+    { "agent": "SummaryAgent",  "action": "まとめ",        "result": "最終レポートテキスト" }
+  ]
+}
+```
+
+## エージェント役割
+
+| エージェント | 役割 |
+|------------|------|
+| OrchestratorAgent | タスクを 2〜4 個のサブタスクに分解 |
+| ResearchAgent | 各サブタスクの情報収集 |
+| SummaryAgent | 全収集結果のまとめ・レポート作成 |
+
+## コスト注意
+
+1 リクエストで Gemini API を複数回呼び出します（OrchestratorAgent 1 回 + ResearchAgent × N 回 + SummaryAgent 1 回）。レート制限に注意してください。
+
+## よくあるエラーと対処
+
+| エラー | 原因 | 対処 |
+|--------|------|------|
+| 400 Bad Request | message なし | リクエストを確認 |
+| 503 | Gemini 障害 | リトライ |
+| タイムアウト | エージェント連鎖に時間かかる | タイムアウト値を延長（60s 以上） |

--- a/.github/docs/features/agent/14-multi-agent/test-cases.md
+++ b/.github/docs/features/agent/14-multi-agent/test-cases.md
@@ -1,0 +1,47 @@
+# テストケース - マルチエージェント
+
+## 正常系
+
+| # | 入力 message | 期待エージェント呼び出し | 期待する応答の要素 |
+|---|-------------|----------------------|----------------|
+| 1 | 「TypeScript と Python の比較レポート」 | Orchestrator + Research × 2 + Summary | 両言語の比較内容 |
+| 2 | 「Node.js についてまとめて」 | Orchestrator + Research + Summary | Node.js 情報 |
+| 3 | 「AI と機械学習の違いを調べて」 | Orchestrator + Research × 2 + Summary | 両用語の説明 |
+
+## 境界値
+
+| # | 入力 | 期待動作 |
+|---|------|---------|
+| 4 | タスク分解が 1 件のみ | ResearchAgent 1 回 + SummaryAgent |
+| 5 | タスク分解が 4 件 | ResearchAgent 3 回 + SummaryAgent |
+| 6 | 検索 DB にヒットしないトピック | "情報なし" をもとに回答 |
+
+## 異常系
+
+| # | 入力 | 期待 HTTP ステータス |
+|---|------|-------------------|
+| 7 | message なし | 400 |
+| 8 | Gemini API 障害（Orchestrator） | 503 |
+| 9 | Gemini API 障害（SummaryAgent） | 503 |
+
+## ユニットテスト: OrchestratorAgent
+
+| # | message | 期待タスク数 |
+|---|---------|-----------|
+| 10 | 「TypeScript と Python の比較」 | 2〜4 件 |
+| 11 | 「Node.js まとめ」 | 2〜3 件 |
+
+## ユニットテスト: ResearchAgent
+
+| # | topic | 期待結果 |
+|---|-------|---------|
+| 12 | "TypeScript" | TypeScript 情報を含む |
+| 13 | "Python" | Python 情報を含む |
+| 14 | "全くマッチしないトピック" | "情報なし" ベースの回答 |
+
+## agentLog 確認
+
+| # | シナリオ | 期待 agentLog |
+|---|---------|-------------|
+| 15 | 正常実行 | Orchestrator → ResearchAgent × N → SummaryAgent の順 |
+| 16 | 各エントリ | agent, action, result すべて存在 |

--- a/e2e/agent/multi-agent.spec.ts
+++ b/e2e/agent/multi-agent.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Agent multi-agent', () => {
+  test('GET /health - 200を返す', async ({ request }) => {
+    const res = await request.get('/node/agent/multi-agent/health');
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe('ok');
+  });
+
+  test('POST /chat - message未指定で400を返す', async ({ request }) => {
+    const res = await request.post('/node/agent/multi-agent/chat', { data: {} });
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('MISSING_MESSAGE');
+  });
+
+  test('POST /chat - 空文字で400を返す', async ({ request }) => {
+    const res = await request.post('/node/agent/multi-agent/chat', { data: { message: '' } });
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('MISSING_MESSAGE');
+  });
+});

--- a/e2e/demo/agent-multi-agent.spec.ts
+++ b/e2e/demo/agent-multi-agent.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test';
+import { showCaption, highlightAndClick, highlightElement } from '../helpers';
+
+const BASE = '/node/agent/multi-agent';
+
+test.describe('Demo: マルチエージェント', () => {
+  test('エージェントUIデモ - 複数エージェントの協調動作', async ({ page }) => {
+    test.setTimeout(90000);
+    await page.route(`${BASE}/chat`, async (route) => {
+      const body = route.request().postDataJSON() as { message?: string };
+      if (!body.message || body.message.trim() === '') {
+        await route.fulfill({ status: 400, contentType: 'application/json', body: JSON.stringify({ error: 'MISSING_MESSAGE', message: 'messageは必須です' }) });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          reply: 'TypeScript と Python の比較レポート：TypeScript は大規模開発で型安全性を提供し、コードの保守性を向上させます。Python は AI/ML 分野での豊富なライブラリが強みで、手軽にデータ処理が可能です。用途に応じた使い分けが重要です。',
+          agentLog: [
+            { agent: 'Orchestrator', action: 'タスク分解', result: ['TypeScript の特徴を調査', 'Python の特徴を調査', '比較レポート作成'] },
+            { agent: 'ResearchAgent', action: 'TypeScript の特徴を調査', result: 'TypeScript は Microsoft 製の型付き言語で大規模開発に適しています。' },
+            { agent: 'ResearchAgent', action: 'Python の特徴を調査', result: 'Python は動的型付けで AI/ML 分野で広く利用されています。' },
+            { agent: 'SummaryAgent', action: 'まとめ', result: 'TypeScript と Python の比較レポート：TypeScript は大規模開発向き、Python は AI/ML 向きです。' },
+          ],
+        }),
+      });
+    });
+
+    await page.goto(BASE);
+    await showCaption(page, 'マルチエージェントを開きました', 2000);
+
+    await highlightElement(page, '.pipeline');
+    await showCaption(page, 'Orchestrator → ResearchAgent × N → SummaryAgent のパイプライン', 2000);
+
+    await showCaption(page, '① クエリ例「TypeScript vs Python 比較」をクリックします');
+    await highlightAndClick(page, '.example-btn:first-child');
+    await showCaption(page, 'タスクがセットされました', 1500);
+
+    await showCaption(page, '② 実行ボタンをクリックして複数エージェントを起動します');
+    await highlightAndClick(page, '#sendBtn');
+
+    await page.waitForSelector('#result', { state: 'visible', timeout: 15000 });
+    await page.waitForSelector('#replyText:not(:empty)', { timeout: 15000 });
+    await showCaption(page, '4つのエージェントが順番に動作しました', 2000);
+
+    await highlightElement(page, '#replyText');
+    const reply = await page.locator('#replyText').textContent();
+    expect(reply).toContain('TypeScript');
+    await showCaption(page, 'SummaryAgent が最終レポートを生成しました', 2000);
+
+    await highlightElement(page, '#agentLog');
+    await showCaption(page, 'エージェントログ - 各エージェントの実行結果が可視化されています', 2000);
+
+    const logEntries = await page.locator('.log-entry').count();
+    expect(logEntries).toBe(4);
+    await showCaption(page, `${logEntries}件のエージェントアクションが記録されました`, 2000);
+
+    await showCaption(page, '✅ マルチエージェントデモ完了', 2000);
+  });
+});

--- a/src/agent/multi-agent/controller.ts
+++ b/src/agent/multi-agent/controller.ts
@@ -1,0 +1,23 @@
+import { Request, Response } from 'express';
+import { MultiAgentService } from './service';
+import { MultiAgentRequest } from '../../interfaces/agent-multi';
+
+const service = new MultiAgentService();
+
+export const health = (_req: Request, res: Response): void => {
+  res.json({ status: 'ok', feature: 'multi-agent' });
+};
+
+export const chat = async (req: Request, res: Response): Promise<void> => {
+  const { message } = req.body as MultiAgentRequest;
+  if (!message || message.trim() === '') {
+    res.status(400).json({ error: 'MISSING_MESSAGE', message: 'messageは必須です' });
+    return;
+  }
+  try {
+    const result = await service.run(message.trim());
+    res.json(result);
+  } catch {
+    res.status(503).json({ error: 'AGENT_ERROR', message: 'マルチエージェントの実行に失敗しました' });
+  }
+};

--- a/src/agent/multi-agent/router.ts
+++ b/src/agent/multi-agent/router.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import rateLimit from 'express-rate-limit';
+import { chat, health } from './controller';
+
+const router = Router();
+
+const limiter = rateLimit({ windowMs: 60 * 1000, max: 20 });
+
+router.get('/health', health);
+router.post('/chat', limiter, chat);
+
+export default router;

--- a/src/agent/multi-agent/service.ts
+++ b/src/agent/multi-agent/service.ts
@@ -1,0 +1,106 @@
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import { config } from '../../shared/config';
+import { AgentLogEntry, MultiAgentResponse, ResearchResult } from '../../interfaces/agent-multi';
+
+const SEARCH_DB: Map<string, string> = new Map([
+  ['TypeScript', 'TypeScript は Microsoft 製の静的型付け言語。JavaScript のスーパーセット。大規模開発で型安全性を提供。'],
+  ['Python', 'Python は動的型付けのインタープリタ言語。科学計算・AI/ML 分野で広く使われる。学習コストが低い。'],
+  ['比較', 'TypeScript: 型安全・大規模開発向き。Python: 手軽・AI/ML 向き。用途によって使い分けが重要。'],
+  ['Node.js', 'Node.js は V8 エンジン上で動作する JS ランタイム。非同期 I/O により高スループットを実現。npm 資産が豊富。'],
+  ['React', 'React は Meta 製の UI ライブラリ。コンポーネントベース・仮想 DOM・フックが特徴。SPA 開発に広く利用。'],
+  ['AI', 'AI（人工知能）は機械に人間の知性を模倣させる技術領域。機械学習・深層学習・自然言語処理などを含む。'],
+  ['機械学習', '機械学習は AI の一分野。データからパターンを学習しモデルを構築する。教師あり・なし・強化学習がある。'],
+  ['Docker', 'Docker はコンテナ仮想化プラットフォーム。アプリと依存関係をイメージにパッケージング。環境差異を解消。'],
+  ['Kubernetes', 'Kubernetes はコンテナオーケストレーション基盤。Pod・Service・Deployment でアプリを管理。自動スケーリング対応。'],
+]);
+
+export class OrchestratorAgent {
+  private genAI: GoogleGenerativeAI;
+
+  constructor() {
+    this.genAI = new GoogleGenerativeAI(config.gemini.apiKey);
+  }
+
+  async decomposeTask(message: string): Promise<string[]> {
+    const model = this.genAI.getGenerativeModel({ model: 'gemini-flash-latest' });
+    const prompt = `以下のタスクを 2〜4 個のサブタスクに分解してください。
+タスク: "${message}"
+JSON 配列（文字列のリスト）のみを返してください。例: ["サブタスク1", "サブタスク2", "まとめ作成"]`;
+
+    const result = await model.generateContent(prompt);
+    const raw = result.response.text().trim();
+    try {
+      const jsonMatch = raw.match(/\[[\s\S]*\]/);
+      if (!jsonMatch) return [message, 'まとめ作成'];
+      const parsed = JSON.parse(jsonMatch[0]) as string[];
+      return Array.isArray(parsed) && parsed.length > 0 ? parsed : [message, 'まとめ作成'];
+    } catch {
+      return [message, 'まとめ作成'];
+    }
+  }
+}
+
+export class ResearchAgent {
+  private genAI: GoogleGenerativeAI;
+
+  constructor() {
+    this.genAI = new GoogleGenerativeAI(config.gemini.apiKey);
+  }
+
+  async research(topic: string): Promise<string> {
+    const localResult =
+      [...SEARCH_DB.entries()].find(([key]) => topic.includes(key))?.[1] ?? '情報なし';
+    const model = this.genAI.getGenerativeModel({ model: 'gemini-flash-latest' });
+    const prompt = `次の情報をもとに "${topic}" について 2〜3 文でまとめてください: ${localResult}`;
+    const result = await model.generateContent(prompt);
+    return result.response.text().trim();
+  }
+}
+
+export class SummaryAgent {
+  private genAI: GoogleGenerativeAI;
+
+  constructor() {
+    this.genAI = new GoogleGenerativeAI(config.gemini.apiKey);
+  }
+
+  async summarize(results: ResearchResult[]): Promise<string> {
+    const model = this.genAI.getGenerativeModel({ model: 'gemini-flash-latest' });
+    const context = results.map((r) => `【${r.topic}】\n${r.content}`).join('\n\n');
+    const prompt = `次の調査結果をもとに、わかりやすいレポートを作成してください:\n\n${context}`;
+    const result = await model.generateContent(prompt);
+    return result.response.text().trim();
+  }
+}
+
+export class MultiAgentService {
+  private orchestrator: OrchestratorAgent;
+  private researchAgent: ResearchAgent;
+  private summaryAgent: SummaryAgent;
+
+  constructor() {
+    this.orchestrator = new OrchestratorAgent();
+    this.researchAgent = new ResearchAgent();
+    this.summaryAgent = new SummaryAgent();
+  }
+
+  async run(message: string): Promise<MultiAgentResponse> {
+    const log: AgentLogEntry[] = [];
+
+    const tasks = await this.orchestrator.decomposeTask(message);
+    log.push({ agent: 'Orchestrator', action: 'タスク分解', result: tasks });
+
+    const researchTasks = tasks.length > 1 ? tasks.slice(0, -1) : tasks;
+    const results: ResearchResult[] = [];
+    for (const task of researchTasks) {
+      const content = await this.researchAgent.research(task);
+      results.push({ topic: task, content });
+      log.push({ agent: 'ResearchAgent', action: task, result: content });
+    }
+
+    const summary = await this.summaryAgent.summarize(results);
+    log.push({ agent: 'SummaryAgent', action: 'まとめ', result: summary });
+
+    return { reply: summary, agentLog: log };
+  }
+}

--- a/src/agent/multi-agent/service.ts
+++ b/src/agent/multi-agent/service.ts
@@ -22,7 +22,7 @@ export class OrchestratorAgent {
   }
 
   async decomposeTask(message: string): Promise<string[]> {
-    const model = this.genAI.getGenerativeModel({ model: 'gemini-flash-latest' });
+    const model = this.genAI.getGenerativeModel({ model: 'gemini-flash-lite-latest' });
     const prompt = `以下のタスクを 2〜4 個のサブタスクに分解してください。
 タスク: "${message}"
 JSON 配列（文字列のリスト）のみを返してください。例: ["サブタスク1", "サブタスク2", "まとめ作成"]`;
@@ -50,7 +50,7 @@ export class ResearchAgent {
   async research(topic: string): Promise<string> {
     const localResult =
       [...SEARCH_DB.entries()].find(([key]) => topic.includes(key))?.[1] ?? '情報なし';
-    const model = this.genAI.getGenerativeModel({ model: 'gemini-flash-latest' });
+    const model = this.genAI.getGenerativeModel({ model: 'gemini-flash-lite-latest' });
     const prompt = `次の情報をもとに "${topic}" について 2〜3 文でまとめてください: ${localResult}`;
     const result = await model.generateContent(prompt);
     return result.response.text().trim();
@@ -65,7 +65,7 @@ export class SummaryAgent {
   }
 
   async summarize(results: ResearchResult[]): Promise<string> {
-    const model = this.genAI.getGenerativeModel({ model: 'gemini-flash-latest' });
+    const model = this.genAI.getGenerativeModel({ model: 'gemini-flash-lite-latest' });
     const context = results.map((r) => `【${r.topic}】\n${r.content}`).join('\n\n');
     const prompt = `次の調査結果をもとに、わかりやすいレポートを作成してください:\n\n${context}`;
     const result = await model.generateContent(prompt);

--- a/src/agent/multi-agent/tests/service.test.ts
+++ b/src/agent/multi-agent/tests/service.test.ts
@@ -1,0 +1,163 @@
+import { OrchestratorAgent, ResearchAgent, SummaryAgent, MultiAgentService } from '../service';
+
+const mockGenerateContent = jest.fn();
+
+jest.mock('@google/generative-ai', () => {
+  const MockGoogleGenerativeAI = jest.fn(() => ({
+    getGenerativeModel: jest.fn(() => ({
+      generateContent: mockGenerateContent,
+    })),
+  }));
+  return { GoogleGenerativeAI: MockGoogleGenerativeAI };
+});
+
+jest.mock('../../../shared/config', () => ({
+  config: { gemini: { apiKey: 'test-key' } },
+}));
+
+const makeResponse = (text: string) => ({ response: { text: () => text } });
+
+describe('OrchestratorAgent', () => {
+  let agent: OrchestratorAgent;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    agent = new OrchestratorAgent();
+  });
+
+  it('タスク配列を返す', async () => {
+    mockGenerateContent.mockResolvedValueOnce(makeResponse('["TypeScript 調査", "Python 調査", "比較まとめ"]'));
+    const tasks = await agent.decomposeTask('TypeScript と Python の比較');
+    expect(Array.isArray(tasks)).toBe(true);
+    expect(tasks.length).toBeGreaterThanOrEqual(2);
+    expect(tasks[0]).toBe('TypeScript 調査');
+  });
+
+  it('JSONパース失敗時はフォールバックで 2 件返す', async () => {
+    mockGenerateContent.mockResolvedValueOnce(makeResponse('申し訳ありませんが JSON ではありません'));
+    const tasks = await agent.decomposeTask('Node.js まとめ');
+    expect(tasks.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('コードブロック付き JSON を正しくパースする', async () => {
+    mockGenerateContent.mockResolvedValueOnce(makeResponse('```json\n["AI 調査", "ML 調査", "まとめ"]\n```'));
+    const tasks = await agent.decomposeTask('AI と機械学習の違いを調べて');
+    expect(tasks).toContain('AI 調査');
+  });
+});
+
+describe('ResearchAgent', () => {
+  let agent: ResearchAgent;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    agent = new ResearchAgent();
+  });
+
+  it('TypeScript トピックで DB ヒット後に Gemini 回答を返す', async () => {
+    mockGenerateContent.mockResolvedValueOnce(makeResponse('TypeScript は型安全な言語です。'));
+    const result = await agent.research('TypeScript の特徴を調査');
+    expect(result).toBe('TypeScript は型安全な言語です。');
+  });
+
+  it('Python トピックで DB ヒット後に Gemini 回答を返す', async () => {
+    mockGenerateContent.mockResolvedValueOnce(makeResponse('Python は AI/ML に広く使われます。'));
+    const result = await agent.research('Python 調査');
+    expect(result).toBe('Python は AI/ML に広く使われます。');
+  });
+
+  it('DB にないトピックは「情報なし」ベースで Gemini を呼ぶ', async () => {
+    mockGenerateContent.mockResolvedValueOnce(makeResponse('情報が不足しています。'));
+    const result = await agent.research('全くマッチしないトピックXYZ');
+    expect(result).toBe('情報が不足しています。');
+    const callArg = mockGenerateContent.mock.calls[0][0] as string;
+    expect(callArg).toContain('情報なし');
+  });
+});
+
+describe('SummaryAgent', () => {
+  let agent: SummaryAgent;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    agent = new SummaryAgent();
+  });
+
+  it('調査結果をまとめたレポートを返す', async () => {
+    mockGenerateContent.mockResolvedValueOnce(makeResponse('TypeScript と Python の比較レポート：...'));
+    const result = await agent.summarize([
+      { topic: 'TypeScript', content: 'TypeScript は...' },
+      { topic: 'Python', content: 'Python は...' },
+    ]);
+    expect(result).toBe('TypeScript と Python の比較レポート：...');
+  });
+
+  it('空配列でも呼び出しに成功する', async () => {
+    mockGenerateContent.mockResolvedValueOnce(makeResponse('情報がありません。'));
+    const result = await agent.summarize([]);
+    expect(result).toBe('情報がありません。');
+  });
+});
+
+describe('MultiAgentService', () => {
+  let service: MultiAgentService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new MultiAgentService();
+  });
+
+  it('全エージェントが協調して agentLog を返す', async () => {
+    mockGenerateContent
+      .mockResolvedValueOnce(makeResponse('["TypeScript 調査", "Python 調査", "まとめ作成"]')) // Orchestrator
+      .mockResolvedValueOnce(makeResponse('TypeScriptの説明'))  // Research 1
+      .mockResolvedValueOnce(makeResponse('Pythonの説明'))      // Research 2
+      .mockResolvedValueOnce(makeResponse('最終レポート'));      // Summary
+
+    const result = await service.run('TypeScript と Python の比較');
+    expect(result.reply).toBe('最終レポート');
+    expect(result.agentLog).toHaveLength(4);
+    expect(result.agentLog[0].agent).toBe('Orchestrator');
+    expect(result.agentLog[0].action).toBe('タスク分解');
+    expect(result.agentLog[1].agent).toBe('ResearchAgent');
+    expect(result.agentLog[2].agent).toBe('ResearchAgent');
+    expect(result.agentLog[3].agent).toBe('SummaryAgent');
+  });
+
+  it('agentLog の各エントリに agent・action・result がある', async () => {
+    mockGenerateContent
+      .mockResolvedValueOnce(makeResponse('["Node.js 調査", "まとめ"]'))
+      .mockResolvedValueOnce(makeResponse('Node.js の説明'))
+      .mockResolvedValueOnce(makeResponse('Node.js レポート'));
+
+    const result = await service.run('Node.js についてまとめて');
+    result.agentLog.forEach((entry) => {
+      expect(entry.agent).toBeTruthy();
+      expect(entry.action).toBeTruthy();
+      expect(entry.result).toBeTruthy();
+    });
+  });
+
+  it('タスク分解が 1 件のみの場合も正常動作する', async () => {
+    mockGenerateContent
+      .mockResolvedValueOnce(makeResponse('["まとめ"]'))  // Orchestrator: 1 task
+      .mockResolvedValueOnce(makeResponse('調査結果'))     // Research (task[0] used)
+      .mockResolvedValueOnce(makeResponse('レポート'));    // Summary
+
+    const result = await service.run('簡単なまとめ');
+    expect(result.agentLog.some((e) => e.agent === 'ResearchAgent')).toBe(true);
+    expect(result.agentLog.some((e) => e.agent === 'SummaryAgent')).toBe(true);
+  });
+
+  it('Orchestrator の result が配列になっている', async () => {
+    mockGenerateContent
+      .mockResolvedValueOnce(makeResponse('["AI 調査", "ML 調査", "まとめ"]'))
+      .mockResolvedValueOnce(makeResponse('AI 説明'))
+      .mockResolvedValueOnce(makeResponse('ML 説明'))
+      .mockResolvedValueOnce(makeResponse('AI/ML レポート'));
+
+    const result = await service.run('AI と機械学習の違いを調べて');
+    const orchLog = result.agentLog.find((e) => e.agent === 'Orchestrator');
+    expect(Array.isArray(orchLog?.result)).toBe(true);
+  });
+});

--- a/src/agent/multi-agent/views/multi-agent.html
+++ b/src/agent/multi-agent/views/multi-agent.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>マルチエージェント</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: 'Segoe UI', sans-serif; background: #0f172a; color: #e2e8f0; min-height: 100vh; padding: 24px; }
+    .container { max-width: 820px; margin: 0 auto; }
+    h1 { font-size: 1.5rem; font-weight: 700; color: #a78bfa; margin-bottom: 4px; }
+    .subtitle { font-size: 0.875rem; color: #94a3b8; margin-bottom: 24px; }
+    .pipeline { display: flex; align-items: center; gap: 6px; margin-bottom: 24px; flex-wrap: wrap; }
+    .agent-chip { padding: 6px 14px; border-radius: 20px; font-size: 0.8rem; font-weight: 600; }
+    .chip-orch   { background: #1e3a5f; color: #60a5fa; border: 1px solid #2563eb; }
+    .chip-research { background: #1a3a2a; color: #4ade80; border: 1px solid #16a34a; }
+    .chip-summary { background: #2d1f5e; color: #c084fc; border: 1px solid #7c3aed; }
+    .arrow { color: #475569; font-size: 1rem; }
+    .card { background: #1e293b; border-radius: 12px; padding: 20px; margin-bottom: 16px; }
+    .label { font-size: 0.75rem; color: #94a3b8; margin-bottom: 8px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; }
+    .examples { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 16px; }
+    .example-btn {
+      background: #1e293b; border: 1px solid #334155; color: #94a3b8;
+      border-radius: 20px; padding: 6px 14px; font-size: 0.8rem; cursor: pointer;
+      transition: all 0.2s;
+    }
+    .example-btn:hover { border-color: #7c3aed; color: #c084fc; }
+    textarea {
+      width: 100%; background: #0f172a; border: 1px solid #334155; color: #e2e8f0;
+      border-radius: 8px; padding: 12px; font-size: 0.95rem; resize: vertical;
+      min-height: 72px; font-family: inherit;
+    }
+    textarea:focus { outline: none; border-color: #7c3aed; }
+    #sendBtn {
+      margin-top: 12px; background: #7c3aed; color: #fff; border: none;
+      border-radius: 8px; padding: 10px 28px; font-size: 0.95rem; cursor: pointer;
+      font-weight: 600; transition: background 0.2s; display: block; margin-left: auto;
+    }
+    #sendBtn:hover { background: #6d28d9; }
+    #sendBtn:disabled { background: #334155; color: #64748b; cursor: not-allowed; }
+    #result { display: none; }
+    .reply-box { background: #0f172a; border-left: 4px solid #a78bfa; border-radius: 8px; padding: 16px; line-height: 1.7; white-space: pre-wrap; }
+    .log-entry { display: flex; gap: 12px; padding: 12px; border-radius: 8px; margin-bottom: 8px; background: #0f172a; }
+    .agent-badge { font-size: 0.72rem; font-weight: 700; padding: 3px 10px; border-radius: 12px; white-space: nowrap; height: fit-content; margin-top: 2px; }
+    .badge-orch    { background: #1e3a5f; color: #60a5fa; }
+    .badge-research { background: #1a3a2a; color: #4ade80; }
+    .badge-summary  { background: #2d1f5e; color: #c084fc; }
+    .log-body { flex: 1; }
+    .log-action { font-size: 0.8rem; color: #94a3b8; margin-bottom: 4px; }
+    .log-result { font-size: 0.85rem; color: #e2e8f0; line-height: 1.5; }
+    .log-result-list { list-style: none; padding: 0; }
+    .log-result-list li::before { content: '▸ '; color: #60a5fa; }
+    #error { display: none; background: #450a0a; border: 1px solid #ef4444; border-radius: 8px; padding: 12px; color: #fca5a5; margin-top: 12px; }
+    .loading-dots::after { content: ''; animation: dots 1.2s infinite; }
+    @keyframes dots { 0%{content:'.'} 33%{content:'..'} 66%{content:'...'} 100%{content:''} }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>マルチエージェント</h1>
+    <p class="subtitle">複数の専門エージェントが協調してタスクを解決します</p>
+
+    <div class="pipeline">
+      <span class="agent-chip chip-orch">Orchestrator</span>
+      <span class="arrow">→ タスク分解 →</span>
+      <span class="agent-chip chip-research">ResearchAgent × N</span>
+      <span class="arrow">→ 調査 →</span>
+      <span class="agent-chip chip-summary">SummaryAgent</span>
+      <span class="arrow">→ レポート</span>
+    </div>
+
+    <div class="card">
+      <div class="label">クエリ例</div>
+      <div class="examples">
+        <button class="example-btn" onclick="setQuery('TypeScript と Python の開発効率を比較したレポートを作成してください')">TypeScript vs Python 比較</button>
+        <button class="example-btn" onclick="setQuery('AI と機械学習の違いを調べてレポートにまとめてください')">AI と機械学習</button>
+        <button class="example-btn" onclick="setQuery('Docker と Kubernetes の役割をまとめてください')">Docker と Kubernetes</button>
+      </div>
+      <div class="label">タスク</div>
+      <textarea id="queryInput" placeholder="複数のエージェントに任せたいタスクを入力してください..."></textarea>
+      <button id="sendBtn" onclick="startAgent()">実行</button>
+      <div id="error"></div>
+    </div>
+
+    <div id="result">
+      <div class="card">
+        <div class="label">最終レポート</div>
+        <div id="replyText" class="reply-box"></div>
+      </div>
+      <div class="card">
+        <div class="label">エージェントログ</div>
+        <div id="agentLog"></div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    function setQuery(text) {
+      document.getElementById('queryInput').value = text;
+    }
+
+    function agentBadgeClass(agent) {
+      if (agent === 'Orchestrator') return 'badge-orch';
+      if (agent === 'ResearchAgent') return 'badge-research';
+      return 'badge-summary';
+    }
+
+    function renderResult(result) {
+      const resultEl = Array.isArray(result)
+        ? `<ul class="log-result-list">${result.map(r => `<li>${escapeHtml(r)}</li>`).join('')}</ul>`
+        : `<div class="log-result">${escapeHtml(String(result))}</div>`;
+      return resultEl;
+    }
+
+    async function startAgent() {
+      const query = document.getElementById('queryInput').value.trim();
+      if (!query) return;
+
+      const btn = document.getElementById('sendBtn');
+      const error = document.getElementById('error');
+      const result = document.getElementById('result');
+
+      btn.disabled = true;
+      btn.textContent = '実行中...';
+      error.style.display = 'none';
+      result.style.display = 'none';
+      document.getElementById('replyText').innerHTML = '<span class="loading-dots">エージェントが協調して処理中</span>';
+      document.getElementById('agentLog').innerHTML = '';
+      result.style.display = 'block';
+
+      try {
+        const res = await fetch('/node/agent/multi-agent/chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ message: query }),
+        });
+        const data = await res.json();
+        if (!res.ok) {
+          error.textContent = data.message || 'エラーが発生しました';
+          error.style.display = 'block';
+          result.style.display = 'none';
+          return;
+        }
+
+        document.getElementById('replyText').textContent = data.reply;
+
+        const logEl = document.getElementById('agentLog');
+        (data.agentLog || []).forEach(entry => {
+          const div = document.createElement('div');
+          div.className = 'log-entry';
+          div.innerHTML = `
+            <span class="agent-badge ${agentBadgeClass(entry.agent)}">${escapeHtml(entry.agent)}</span>
+            <div class="log-body">
+              <div class="log-action">${escapeHtml(entry.action)}</div>
+              ${renderResult(entry.result)}
+            </div>
+          `;
+          logEl.appendChild(div);
+        });
+      } catch {
+        error.textContent = '通信エラーが発生しました';
+        error.style.display = 'block';
+        result.style.display = 'none';
+      } finally {
+        btn.disabled = false;
+        btn.textContent = '実行';
+      }
+    }
+
+    function escapeHtml(str) {
+      return String(str)
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    }
+  </script>
+</body>
+</html>

--- a/src/agent/research/service.ts
+++ b/src/agent/research/service.ts
@@ -75,14 +75,14 @@ export class ResearchService {
   }
 
   async summarize(text: string): Promise<string> {
-    const model = this.genAI.getGenerativeModel({ model: 'gemini-flash-latest' });
+    const model = this.genAI.getGenerativeModel({ model: 'gemini-flash-lite-latest' });
     const prompt = `以下の情報を100字以内で簡潔にまとめてください：\n\n${text}`;
     const result = await model.generateContent(prompt);
     return result.response.text().trim();
   }
 
   async decideNext(summary: string, originalQuestion: string): Promise<NextDecision> {
-    const model = this.genAI.getGenerativeModel({ model: 'gemini-flash-latest' });
+    const model = this.genAI.getGenerativeModel({ model: 'gemini-flash-lite-latest' });
     const prompt = `元の質問: "${originalQuestion}"
 現在の調査要約: ${summary}
 
@@ -108,7 +108,7 @@ export class ResearchService {
   }
 
   private async generateFinalReply(originalQuestion: string, summaries: string[]): Promise<string> {
-    const model = this.genAI.getGenerativeModel({ model: 'gemini-flash-latest' });
+    const model = this.genAI.getGenerativeModel({ model: 'gemini-flash-lite-latest' });
     const summaryText = summaries.map((s, i) => `[${i + 1}] ${s}`).join('\n');
     const prompt = `以下の調査結果をもとに、「${originalQuestion}」について包括的に回答してください：\n\n${summaryText}`;
     const result = await model.generateContent(prompt);

--- a/src/agent/router.ts
+++ b/src/agent/router.ts
@@ -13,6 +13,7 @@ import dataAggregationRouter from './data-aggregation/router';
 import ragAgentRouter from './rag-agent/router';
 import langGraphRouter from './langgraph/router';
 import researchRouter from './research/router';
+import multiAgentRouter from './multi-agent/router';
 import path from 'path';
 
 const router = Router();
@@ -87,7 +88,11 @@ router.get('/research', (_req: Request, res: Response) => {
   res.sendFile(path.join(__dirname, 'research', 'views', 'research-agent.html'));
 });
 router.use('/research', researchRouter);
-router.get('/multi', placeholder('マルチエージェント'));
+// #81 マルチエージェント
+router.get('/multi-agent', (_req: Request, res: Response) => {
+  res.sendFile(path.join(__dirname, 'multi-agent', 'views', 'multi-agent.html'));
+});
+router.use('/multi-agent', multiAgentRouter);
 router.get('/credit-check-dotnet', placeholder('与信チェック + dotnet連携'));
 
 export default router;

--- a/src/interfaces/agent-multi.ts
+++ b/src/interfaces/agent-multi.ts
@@ -1,0 +1,19 @@
+export interface AgentLogEntry {
+  agent: 'Orchestrator' | 'ResearchAgent' | 'SummaryAgent';
+  action: string;
+  result: string | string[];
+}
+
+export interface ResearchResult {
+  topic: string;
+  content: string;
+}
+
+export interface MultiAgentRequest {
+  message: string;
+}
+
+export interface MultiAgentResponse {
+  reply: string;
+  agentLog: AgentLogEntry[];
+}


### PR DESCRIPTION
## Summary

- Orchestrator → ResearchAgent × N → SummaryAgent の 3 エージェントが協調して動作するマルチエージェントを実装
- OrchestratorAgent がタスクを 2〜4 個に分解し、ResearchAgent が各サブタスクを調査、SummaryAgent が最終レポートを生成
- `agentLog` で各エージェントのアクションと結果を可視化

## Changes

- `src/interfaces/agent-multi.ts` - 型定義（AgentLogEntry, ResearchResult, MultiAgentResponse）
- `src/agent/multi-agent/service.ts` - OrchestratorAgent / ResearchAgent / SummaryAgent / MultiAgentService
- `src/agent/multi-agent/controller.ts` / `router.ts` - REST API
- `src/agent/multi-agent/views/multi-agent.html` - パイプライン可視化 UI
- `src/agent/router.ts` - `/multi-agent` ルート登録（`/multi` プレースホルダーを置換）
- `src/agent/multi-agent/tests/service.test.ts` - Jest 12テスト（全パス）
- `e2e/agent/multi-agent.spec.ts` / `e2e/demo/agent-multi-agent.spec.ts` - Playwright E2E

## Test plan

- [x] `npx jest src/agent/multi-agent/tests/service.test.ts` - 12/12 pass
- [x] `npx tsc --noEmit` - 型エラーなし
- [ ] ブラウザで `GET /node/agent/multi-agent` を開いて動作確認

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)