### PR TITLE
hotfix: Node.js 18→20アップグレード (pdf-parse v2対応)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ===========================
 # Stage 1: Build Stage
 # ===========================
-FROM node:18-alpine AS builder
+FROM node:20-alpine AS builder
 
 WORKDIR /usr/src/app
 
@@ -19,7 +19,7 @@ RUN npm run build
 # ===========================
 # Stage 2: Production Stage
 # ===========================
-FROM node:18-alpine
+FROM node:20-alpine
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
## 原因

`pdf-parse` v2 はPDF.jsをバンドルしており、`DOMMatrix` / `ImageData` / `Path2D` 等のブラウザAPIをNode.js 20+のグローバルに依存しています。Node.js 18ではこれらが未サポートのため、ECSタスクが起動直後にクラッシュしていました。

ECSログ:
```
Warning: Cannot polyfill `DOMMatrix`, rendering may be broken.
Warning: Cannot polyfill `ImageData`, rendering may be broken.
Warning: Cannot polyfill `Path2D`, rendering may be broken.
```

## 修正

`Dockerfile` の `node:18-alpine` → `node:20-alpine` (LTS)

## 影響

- PR #113 (feature/61-rag-pdf) マージ後のECSデプロイが全タスク即時クラッシュ → 修正で解消
- Node.js 20はLTSで後方互換性あり

🤖 Generated with [Claude Code](https://claude.com/claude-code)