### PR TITLE
feat: #64 根拠スコア表示

### DIFF
--- a/.github/docs/features/rag/12-score-display/external-design.md
+++ b/.github/docs/features/rag/12-score-display/external-design.md
@@ -1,0 +1,134 @@
+# RAG #12 根拠スコア表示 - 外部設計書
+
+## 文書情報
+- **作成日**: 2026-03-13
+- **ステータス**: 📝 未着手
+- **Issue**: [#64](https://github.com/RYA234/typescript-container/issues/64)
+- **ソース**: `src/rag/score-display/`
+- **難易度**: 上級
+
+---
+
+## 環境制約
+
+| エンドポイント種別 | 本番環境（NODE_ENV=production） | 開発環境 |
+|------------------|-------------------------------|----------|
+| データ登録・削除（POST/DELETE） | **無効**（ルート未登録） | 有効 |
+| 検索・参照（GET/POST） | 有効 | 有効 |
+
+> **理由**: 本番環境への意図しないデータ書き込みを防ぐため、`router.ts` で `if (!isProduction)` による制御を実施。
+> データ登録は開発環境またはシードスクリプトで行う。
+
+---
+
+## 0. 画面モック
+
+```
+┌──────────────────────────────────────────────────────┐
+│ 根拠スコア表示デモ                                     │
+│ [← Back to Home]  [GitHub Source #64]  [設計書]       │
+├──────────────────────────────────────────────────────┤
+│ 質問:                                                 │
+│ ┌────────────────────────────────────────────────┐   │
+│ │ 有給は何日取れますか？                          │   │
+│ └────────────────────────────────────────────────┘   │
+│ 信頼度しきい値: [0.7] (0〜1)        [質問する]        │
+│                                                      │
+│ 回答:  信頼度: ████████░░ HIGH (0.92)                 │
+│ ┌────────────────────────────────────────────────┐   │
+│ │ 年次有給休暇は勤続6ヶ月以上で10日付与されます。 │   │
+│ │ 以降は勤続年数に応じて最大20日まで増加します。  │   │
+│ └────────────────────────────────────────────────┘   │
+│                                                      │
+│ 参照ソース:                                           │
+│ ┌────────────────────────────────────────────────┐   │
+│ │ [HIGH] 就業規則 チャンク3   ████████░░  92%    │   │
+│ │        年次有給休暇は勤続6ヶ月以上の従業員に... │   │
+│ ├────────────────────────────────────────────────┤   │
+│ │ [MED]  就業規則 チャンク7   ██████░░░░  78%    │   │
+│ │        有給休暇の申請は3日前までに...           │   │
+│ └────────────────────────────────────────────────┘   │
+│ 処理時間: 1500ms                                      │
+└──────────────────────────────────────────────────────┘
+```
+
+---
+
+## 1. 概要
+
+RAGの回答に対して「どのドキュメントの何ページを参照したか」「類似度スコアがいくつか」を合わせて表示する。AIの回答の信頼性・根拠を可視化する。
+
+**ユースケース例**
+- 回答の横に「参照元: 就業規則P.5 (類似度92%)」を表示
+- 類似度が低い場合は「情報が不足している可能性あり」と警告
+
+---
+
+## 2. API設計
+
+| メソッド | パス | 概要 |
+|---------|------|------|
+| POST | /node/rag/scored/query | スコア付きでRAGクエリ |
+
+### POST /node/rag/scored/query
+
+**リクエスト**:
+```json
+{ "question": "有給は何日取れますか？", "confidenceThreshold": 0.7 }
+```
+
+**レスポンス**:
+```json
+{
+  "answer": "年次有給休暇は勤続6ヶ月以上で10日付与されます。",
+  "confidence": "HIGH",
+  "sources": [
+    {
+      "content": "年次有給休暇は勤続6ヶ月以上...",
+      "similarity": 0.92,
+      "documentTitle": "就業規則",
+      "chunkIndex": 3,
+      "confidenceLevel": "HIGH"
+    }
+  ],
+  "warning": null,
+  "executionTimeMs": 1500
+}
+```
+
+**信頼度レベル**:
+| similarity | confidence | 表示 |
+|---|---|---|
+| 0.85以上 | HIGH | 緑 |
+| 0.7〜0.85 | MEDIUM | 黄 |
+| 0.7未満 | LOW | 赤（警告表示） |
+
+---
+
+## 3. シーケンス図
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Controller
+    participant Service
+    participant Gemini
+    participant Supabase
+
+    User->>Controller: POST /scored/query { question, threshold }
+    Controller->>Service: queryWithScore(question, threshold)
+    Service->>Gemini: text-embedding-004(question)
+    Gemini-->>Service: vector(768)
+    Service->>Supabase: match_documents(vector)
+    Supabase-->>Service: チャンク[] with similarity scores
+    Service->>Service: calcConfidenceLevel(similarity)
+    Service->>Gemini: gemini-1.5-flash(question + context)
+    Gemini-->>Service: answer
+    Service-->>Controller: ScoredResponse { answer, confidence, sources[] }
+    Controller-->>User: 200 OK
+```
+
+---
+
+## 4. 参考
+- [RAG実装リスト](../../rag-list.md)

--- a/.github/docs/features/rag/12-score-display/internal-design.md
+++ b/.github/docs/features/rag/12-score-display/internal-design.md
@@ -1,0 +1,116 @@
+# RAG #12 根拠スコア表示 - 内部設計書
+
+## 文書情報
+- **作成日**: 2026-03-13
+- **ステータス**: 📝 未着手
+- **Issue**: [#64](https://github.com/RYA234/typescript-container/issues/64)
+- **ソース**: `src/rag/score-display/`
+
+---
+
+## 環境制約（本番ガード）
+
+`router.ts` で `NODE_ENV === 'production'` の場合、書き込み系エンドポイントを登録しない。
+
+```typescript
+const isProduction = process.env.NODE_ENV === 'production';
+if (!isProduction) {
+  router.post('/ingest', controller.ingest);
+  router.delete('/documents', controller.deleteAll); // 実装する場合
+}
+// 検索系は本番でも有効
+router.get('/search', rateLimiter, controller.search);
+router.post('/query', rateLimiter, controller.query);
+```
+
+---
+
+## 1. 型定義
+
+```typescript
+export type ConfidenceLevel = 'HIGH' | 'MEDIUM' | 'LOW';
+
+export interface ScoredSource {
+  content: string;
+  similarity: number;
+  documentTitle?: string;
+  chunkIndex?: number;
+  confidenceLevel: ConfidenceLevel;
+}
+
+export interface ScoredQueryRequest {
+  question: string;
+  confidenceThreshold?: number;
+}
+
+export interface ScoredQueryResponse {
+  answer: string;
+  confidence: ConfidenceLevel;
+  sources: ScoredSource[];
+  warning: string | null;
+  executionTimeMs: number;
+}
+```
+
+---
+
+## 2. サービス実装詳細
+
+### calcConfidenceLevel
+
+```typescript
+private calcConfidenceLevel(similarity: number): ConfidenceLevel {
+  if (similarity >= 0.85) return 'HIGH';
+  if (similarity >= 0.7) return 'MEDIUM';
+  return 'LOW';
+}
+```
+
+### queryWithScore
+
+```typescript
+async queryWithScore(
+  question: string,
+  threshold = 0.7
+): Promise<ScoredQueryResponse> {
+  const start = Date.now();
+  const embedding = await this.generateEmbedding(question);
+  const { data } = await supabase.rpc('match_documents', {
+    query_embedding: embedding,
+    match_threshold: threshold,
+    match_count: 5
+  });
+
+  const sources: ScoredSource[] = data.map((d: any) => ({
+    content: d.content,
+    similarity: d.similarity,
+    documentTitle: d.metadata?.source,
+    confidenceLevel: this.calcConfidenceLevel(d.similarity)
+  }));
+
+  // 最高スコアから全体の信頼度を判定
+  const maxSimilarity = Math.max(...sources.map(s => s.similarity), 0);
+  const confidence = this.calcConfidenceLevel(maxSimilarity);
+
+  const context = data.map((d: any) => d.content).join('\n\n');
+  const answer = await this.generateAnswer(question, context);
+
+  const warning = confidence === 'LOW'
+    ? '関連情報が不足している可能性があります。回答の精度が低い場合があります。'
+    : null;
+
+  return { answer, confidence, sources, warning, executionTimeMs: Date.now() - start };
+}
+```
+
+---
+
+## 3. テスト方針
+
+```typescript
+describe('ScoredService', () => {
+  it('similarityが0.85以上ならHIGH');
+  it('similarityが0.7〜0.85ならMEDIUM');
+  it('similarityが0.7未満ならLOWでwarningあり');
+});
+```

--- a/.github/docs/features/rag/12-score-display/operation-manual.md
+++ b/.github/docs/features/rag/12-score-display/operation-manual.md
@@ -1,0 +1,126 @@
+# RAG #12 根拠スコア表示 - 操作手順書
+
+## 前提条件
+- `.env` に `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `GEMINI_API_KEY` が設定済み
+- Supabaseに `documents` テーブルと `match_documents` 関数が作成済み
+- サーバーが起動済み（`npm run dev`）
+
+---
+
+## Step 1: Supabase セットアップ
+
+`supabase-setup.md` の手順でテーブルと関数を作成する。
+
+---
+
+## Step 2: テスト用データの登録
+
+```bash
+curl -X POST http://localhost:3000/node/rag/ingest \
+  -H "Content-Type: application/json" \
+  -d '{
+    "text": "有給休暇は年間20日付与されます。繰越は最大20日まで可能です。申請は3日前までに上司へ届け出ること。",
+    "source": "hr-rules"
+  }'
+```
+
+---
+
+## Step 3: スコア付き類似検索
+
+```bash
+curl "http://localhost:3000/node/rag/search?q=有給休暇の日数&limit=3"
+```
+
+期待レスポンス:
+```json
+{
+  "results": [
+    {
+      "content": "有給休暇は年間20日付与されます...",
+      "similarity": 0.92,
+      "confidence": "HIGH",
+      "metadata": { "source": "hr-rules" }
+    }
+  ],
+  "executionTimeMs": 320
+}
+```
+
+---
+
+## Step 4: 信頼度スコアの判定基準確認
+
+HIGH（高信頼）の確認:
+
+```bash
+# 登録テキストと同じキーワードで検索 → similarity >= 0.8
+curl "http://localhost:3000/node/rag/search?q=有給休暇 年間20日&limit=3"
+```
+
+MEDIUM（中信頼）の確認:
+
+```bash
+# 関連するが表現が異なるキーワード → 0.6 <= similarity < 0.8
+curl "http://localhost:3000/node/rag/search?q=休暇制度&limit=3"
+```
+
+LOW（低信頼）の確認:
+
+```bash
+# やや関連するキーワード → 0.5 <= similarity < 0.6
+curl "http://localhost:3000/node/rag/search?q=休み&limit=3"
+```
+
+---
+
+## Step 5: RAGクエリでのスコア表示
+
+```bash
+curl -X POST http://localhost:3000/node/rag/query \
+  -H "Content-Type: application/json" \
+  -d '{"question": "有給休暇は何日もらえますか？"}'
+```
+
+期待レスポンス:
+```json
+{
+  "answer": "有給休暇は年間20日付与されます...",
+  "overall_confidence": "HIGH",
+  "sources": [
+    {
+      "content": "有給休暇は年間20日付与されます...",
+      "similarity": 0.92,
+      "confidence": "HIGH"
+    }
+  ],
+  "executionTimeMs": 1800
+}
+```
+
+---
+
+## Step 6: データ削除（クリーンアップ）
+
+```bash
+curl -X DELETE http://localhost:3000/node/rag/documents
+```
+
+---
+
+## よくあるエラーと対処法
+
+| エラー | 原因 | 対処法 |
+|-------|------|-------|
+| confidence が undefined | スコア判定未実装 | サービス実装を確認 |
+| similarity が閾値未満で結果なし | 検索ワードの類似度不足 | より具体的なキーワードで検索 |
+| スコアが常に同じ | ベクトル生成の問題 | Gemini APIキーを確認 |
+
+## 信頼度判定基準
+
+| 判定 | similarity範囲 | 意味 |
+|-----|--------------|------|
+| HIGH | >= 0.8 | 高い信頼性。根拠として強く支持 |
+| MEDIUM | 0.6 - 0.8 | 中程度の信頼性。参考情報として使用 |
+| LOW | 0.5 - 0.6 | 低い信頼性。別途確認を推奨 |
+| - | < 0.5 | 閾値未満のため結果に含まれない |

--- a/.github/docs/features/rag/12-score-display/test-cases.md
+++ b/.github/docs/features/rag/12-score-display/test-cases.md
@@ -1,0 +1,41 @@
+# RAG #12 根拠スコア表示 - テスト仕様書
+
+## 文書情報
+- 作成日: 2026-03-13
+- ステータス: 📝 未着手
+
+---
+
+## 1. テストケース一覧
+
+| No | テストID | テスト内容 | 入力 | 期待結果 | 優先度 |
+|----|---------|-----------|------|---------|-------|
+| 1 | TC-12-001 | 類似度スコアがレスポンスに含まれる | GET /search?q=... | results[].similarity が数値 | 高 |
+| 2 | TC-12-002 | HIGH判定（similarity >= 0.8） | 高類似度のクエリ | confidence: "HIGH" | 高 |
+| 3 | TC-12-003 | MEDIUM判定（0.6 <= similarity < 0.8） | 中類似度のクエリ | confidence: "MEDIUM" | 高 |
+| 4 | TC-12-004 | LOW判定（0.5 <= similarity < 0.6） | 低類似度のクエリ | confidence: "LOW" | 高 |
+| 5 | TC-12-005 | スコアによる並び順確認 | 複数件の検索結果 | similarity降順で返る | 高 |
+| 6 | TC-12-006 | RAGクエリのsourcesにスコア付与 | POST /query | sources[].similarity が数値 | 高 |
+| 7 | TC-12-007 | overall_confidenceの確認 | POST /query | overall_confidence: "HIGH/MEDIUM/LOW" | 中 |
+| 8 | TC-12-008 | スコアの範囲確認 | 複数クエリ | 0.0 <= similarity <= 1.0 | 高 |
+
+---
+
+## 2. 境界値テスト
+
+| No | テストID | テスト内容 | 入力 | 期待結果 |
+|----|---------|-----------|------|---------|
+| 1 | BV-12-001 | similarity = 0.8ちょうど（HIGH境界） | HIGH/MEDIUMの境界クエリ | confidence: "HIGH" |
+| 2 | BV-12-002 | similarity = 0.6ちょうど（MEDIUM境界） | MEDIUM/LOWの境界クエリ | confidence: "MEDIUM" |
+| 3 | BV-12-003 | similarity = 0.5（閾値ちょうど） | 閾値ちょうどのクエリ | 結果に含まれる |
+| 4 | BV-12-004 | similarity = 1.0（完全一致） | 登録テキストをそのまま検索 | confidence: "HIGH" |
+
+---
+
+## 3. 異常系テスト
+
+| No | テストID | テスト内容 | 入力 | 期待結果 |
+|----|---------|-----------|------|---------|
+| 1 | ERR-12-001 | ドキュメント未登録でスコア確認 | 全削除後にsearch | results.length == 0 |
+| 2 | ERR-12-002 | qなしでスコア付き検索 | GET /search (qなし) | 400 Bad Request |
+| 3 | ERR-12-003 | 無関係なクエリでスコアが閾値未満 | 全く無関係なキーワード | results.length == 0（閾値以下が除外） |

--- a/src/interfaces/rag-score-display.ts
+++ b/src/interfaces/rag-score-display.ts
@@ -1,0 +1,39 @@
+export type ConfidenceLevel = 'HIGH' | 'MEDIUM' | 'LOW';
+
+export interface ScoredSource {
+  content: string;
+  similarity: number;
+  documentTitle: string;
+  chunkIndex: number;
+  confidenceLevel: ConfidenceLevel;
+}
+
+export interface ScoredQueryRequest {
+  question: string;
+  confidenceThreshold?: number;
+}
+
+export interface ScoredQueryResponse {
+  answer: string;
+  confidence: ConfidenceLevel;
+  sources: ScoredSource[];
+  warning: string | null;
+  executionTimeMs: number;
+}
+
+export interface ScoredIngestRequest {
+  text: string;
+  source?: string;
+}
+
+export interface ScoredIngestResponse {
+  success: boolean;
+  chunkCount: number;
+  executionTimeMs: number;
+}
+
+export interface ScoredDeleteResponse {
+  success: boolean;
+  deletedCount: number;
+  message: string;
+}

--- a/src/rag/router.ts
+++ b/src/rag/router.ts
@@ -11,6 +11,7 @@ import dateFilterRouter from './date-filter/router';
 import ragAgentRouter from './rag-agent/router';
 import pdfRouter from './pdf/router';
 import chatHistoryRouter from './chat-history/router';
+import scoredRouter from './score-display/router';
 import path from 'path';
 import rateLimit from 'express-rate-limit';
 
@@ -97,7 +98,11 @@ router.get('/agent', (_req, res) => {
   res.sendFile(path.join(__dirname, 'rag-agent', 'views', 'rag-agent.html'));
 });
 router.use('/agent', ragAgentRouter);
-router.get('/score', placeholder('根拠スコア表示'));
+// #64 根拠スコア表示
+router.get('/score', (_req, res) => {
+  res.sendFile(path.join(__dirname, 'score-display', 'views', 'score-display.html'));
+});
+router.use('/scored', scoredRouter);
 router.get('/eval', placeholder('LangSmith + Ragas評価'));
 router.get('/hybrid', placeholder('ハイブリッド検索'));
 router.get('/multimodal', placeholder('マルチモーダルRAG'));

--- a/src/rag/score-display/controller.ts
+++ b/src/rag/score-display/controller.ts
@@ -1,0 +1,43 @@
+import { Request, Response } from 'express';
+import { ScoredService } from './service';
+import { ScoredIngestRequest, ScoredQueryRequest } from '../../interfaces/rag-score-display';
+
+const service = new ScoredService();
+
+export const ingest = async (req: Request, res: Response): Promise<void> => {
+  const { text, source } = req.body as ScoredIngestRequest;
+  if (!text || text.trim() === '') {
+    res.status(400).json({ error: 'MISSING_TEXT', message: 'textは必須です' });
+    return;
+  }
+  try {
+    const result = await service.ingest(text.trim(), source);
+    res.json(result);
+  } catch {
+    res.status(502).json({ error: 'INGEST_ERROR', message: 'データの登録に失敗しました' });
+  }
+};
+
+export const query = async (req: Request, res: Response): Promise<void> => {
+  const { question, confidenceThreshold } = req.body as ScoredQueryRequest;
+  if (!question || question.trim() === '') {
+    res.status(400).json({ error: 'MISSING_QUESTION', message: 'questionは必須です' });
+    return;
+  }
+  const threshold = typeof confidenceThreshold === 'number' ? confidenceThreshold : 0.3;
+  try {
+    const result = await service.queryWithScore(question.trim(), threshold);
+    res.json(result);
+  } catch {
+    res.status(502).json({ error: 'QUERY_ERROR', message: 'クエリに失敗しました' });
+  }
+};
+
+export const deleteAll = async (_req: Request, res: Response): Promise<void> => {
+  try {
+    const result = await service.deleteAll();
+    res.json(result);
+  } catch {
+    res.status(502).json({ error: 'DELETE_ERROR', message: '削除に失敗しました' });
+  }
+};

--- a/src/rag/score-display/router.ts
+++ b/src/rag/score-display/router.ts
@@ -1,0 +1,26 @@
+import { Router } from 'express';
+import rateLimit from 'express-rate-limit';
+import * as controller from './controller';
+
+const router = Router();
+const isProduction = process.env.NODE_ENV === 'production';
+
+const rateLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'TOO_MANY_REQUESTS', message: 'リクエストが多すぎます。1分後に再試行してください。' },
+});
+
+router.get('/config', (_req, res) => {
+  res.json({ writeEnabled: !isProduction });
+});
+router.post('/query', rateLimiter, controller.query);
+
+if (!isProduction) {
+  router.post('/ingest', controller.ingest);
+  router.delete('/documents', controller.deleteAll);
+}
+
+export default router;

--- a/src/rag/score-display/service.ts
+++ b/src/rag/score-display/service.ts
@@ -1,0 +1,139 @@
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import { config } from '../../shared/config';
+import { SupabaseService } from '../../supabase/service';
+import {
+  ConfidenceLevel,
+  ScoredDeleteResponse,
+  ScoredIngestResponse,
+  ScoredQueryResponse,
+  ScoredSource,
+} from '../../interfaces/rag-score-display';
+
+const CHUNK_SIZE = 500;
+const CHUNK_OVERLAP = 50;
+
+export class ScoredService {
+  private supabaseService: SupabaseService;
+  private genAI: GoogleGenerativeAI;
+
+  constructor() {
+    this.supabaseService = new SupabaseService();
+    this.genAI = new GoogleGenerativeAI(config.gemini.apiKey);
+  }
+
+  async ingest(text: string, source = 'scored-demo'): Promise<ScoredIngestResponse> {
+    const start = Date.now();
+    const supabase = this.supabaseService.getClient();
+    const chunks = this.splitIntoChunks(text, CHUNK_SIZE, CHUNK_OVERLAP);
+
+    for (const chunk of chunks) {
+      const embedding = await this.generateEmbedding(chunk);
+      const { error } = await supabase
+        .from('documents')
+        .insert({ content: chunk, embedding: `[${embedding.join(',')}]`, metadata: { source } });
+      if (error) throw new Error(`Supabase insert error: ${error.message}`);
+    }
+
+    return { success: true, chunkCount: chunks.length, executionTimeMs: Date.now() - start };
+  }
+
+  async queryWithScore(question: string, threshold = 0.3): Promise<ScoredQueryResponse> {
+    const start = Date.now();
+    const supabase = this.supabaseService.getClient();
+    const embedding = await this.generateEmbedding(question);
+
+    const { data, error } = await supabase.rpc('match_documents', {
+      query_embedding: embedding,
+      match_threshold: threshold,
+      match_count: 5,
+    });
+
+    if (error) throw new Error(`Supabase RPC error: ${error.message}`);
+
+    const rows: Array<{ content: string; similarity: number; metadata?: { source?: string } }> = data ?? [];
+
+    const sources: ScoredSource[] = rows.map((d, i) => ({
+      content: d.content,
+      similarity: d.similarity,
+      documentTitle: d.metadata?.source ?? 'ドキュメント',
+      chunkIndex: i + 1,
+      confidenceLevel: this.calcConfidenceLevel(d.similarity),
+    }));
+
+    const maxSimilarity = sources.length > 0 ? Math.max(...sources.map((s) => s.similarity)) : 0;
+    const confidence = sources.length > 0 ? this.calcConfidenceLevel(maxSimilarity) : 'LOW';
+
+    const context = rows.map((d, i) => `[チャンク${i + 1}]\n${d.content}`).join('\n\n');
+    const answer = context
+      ? await this.generateAnswer(question, context)
+      : '関連するドキュメントが見つかりませんでした。';
+
+    const warning =
+      confidence === 'LOW' || sources.length === 0
+        ? '関連情報が不足している可能性があります。回答の精度が低い場合があります。'
+        : null;
+
+    return { answer, confidence, sources, warning, executionTimeMs: Date.now() - start };
+  }
+
+  async deleteAll(): Promise<ScoredDeleteResponse> {
+    const supabase = this.supabaseService.getClient();
+    const { count, error } = await supabase
+      .from('documents')
+      .delete({ count: 'exact' })
+      .neq('id', '00000000-0000-0000-0000-000000000000');
+
+    if (error) throw new Error(`Supabase delete error: ${error.message}`);
+
+    const deletedCount = count ?? 0;
+    return { success: true, deletedCount, message: `${deletedCount}件のドキュメントを削除しました` };
+  }
+
+  private calcConfidenceLevel(similarity: number): ConfidenceLevel {
+    if (similarity >= 0.85) return 'HIGH';
+    if (similarity >= 0.7) return 'MEDIUM';
+    return 'LOW';
+  }
+
+  private splitIntoChunks(text: string, size: number, overlap: number): string[] {
+    const chunks: string[] = [];
+    let i = 0;
+    while (i < text.length) {
+      chunks.push(text.slice(i, i + size));
+      i += size - overlap;
+      if (i + overlap >= text.length) break;
+    }
+    const last = text.slice(Math.max(0, text.length - size));
+    if (chunks.length === 0 || chunks[chunks.length - 1] !== last) chunks.push(last);
+    return chunks.filter((c) => c.trim().length > 0);
+  }
+
+  private async generateEmbedding(text: string): Promise<number[]> {
+    const model = this.genAI.getGenerativeModel({ model: 'gemini-embedding-001' });
+    const result = await model.embedContent({
+      content: { parts: [{ text }], role: 'user' },
+      outputDimensionality: 768,
+    } as Parameters<typeof model.embedContent>[0]);
+    return result.embedding.values;
+  }
+
+  private async generateAnswer(question: string, context: string): Promise<string> {
+    const model = this.genAI.getGenerativeModel({ model: 'gemini-flash-lite-latest' });
+    const prompt = `以下のドキュメントを参考に、質問に日本語で回答してください。
+
+ドキュメント:
+${context}
+
+質問: ${question}`;
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        const result = await model.generateContent(prompt);
+        return result.response.text();
+      } catch (err) {
+        if (attempt === 2) throw err;
+        await new Promise((r) => setTimeout(r, 1000));
+      }
+    }
+    throw new Error('generateAnswer failed');
+  }
+}

--- a/src/rag/score-display/tests/score-display.test.ts
+++ b/src/rag/score-display/tests/score-display.test.ts
@@ -1,0 +1,144 @@
+import { ScoredService } from '../service';
+
+jest.mock('../../../supabase/service');
+jest.mock('@google/generative-ai');
+
+describe('ScoredService', () => {
+  let service: ScoredService;
+
+  beforeEach(() => {
+    service = new ScoredService();
+    jest.clearAllMocks();
+  });
+
+  const mockEmbedding = Array(768).fill(0.1);
+
+  describe('ingest', () => {
+    it('テキストをチャンク分割して登録し結果を返す', async () => {
+      jest.spyOn(service as unknown as { generateEmbedding: () => Promise<number[]> }, 'generateEmbedding')
+        .mockResolvedValue(mockEmbedding);
+
+      const mockInsert = jest.fn().mockResolvedValue({ error: null });
+      const mockFrom = jest.fn().mockReturnValue({ insert: mockInsert });
+
+      jest.spyOn(service['supabaseService'], 'getClient').mockReturnValue({
+        from: mockFrom,
+      } as unknown as ReturnType<typeof service['supabaseService']['getClient']>);
+
+      const result = await service.ingest('テスト文書です。', 'test-source');
+
+      expect(result.success).toBe(true);
+      expect(result.chunkCount).toBeGreaterThan(0);
+      expect(result.executionTimeMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('Supabaseエラー時は例外をスローする', async () => {
+      jest.spyOn(service as unknown as { generateEmbedding: () => Promise<number[]> }, 'generateEmbedding')
+        .mockResolvedValue(mockEmbedding);
+
+      const mockInsert = jest.fn().mockResolvedValue({ error: { message: 'insert failed' } });
+      const mockFrom = jest.fn().mockReturnValue({ insert: mockInsert });
+
+      jest.spyOn(service['supabaseService'], 'getClient').mockReturnValue({
+        from: mockFrom,
+      } as unknown as ReturnType<typeof service['supabaseService']['getClient']>);
+
+      await expect(service.ingest('test')).rejects.toThrow('Supabase insert error');
+    });
+  });
+
+  describe('queryWithScore', () => {
+    it('高スコアのソースがある場合はHIGH信頼度で返す', async () => {
+      const mockData = [
+        { content: '有給休暇は年間20日付与されます。', similarity: 0.9, metadata: { source: 'hr-rules' } },
+        { content: '勤続1年未満は10日。', similarity: 0.87, metadata: { source: 'hr-rules' } },
+      ];
+      const mockRpc = jest.fn().mockResolvedValue({ data: mockData, error: null });
+
+      jest.spyOn(service as unknown as { generateEmbedding: () => Promise<number[]> }, 'generateEmbedding')
+        .mockResolvedValue(mockEmbedding);
+      jest.spyOn(service as unknown as { generateAnswer: () => Promise<string> }, 'generateAnswer')
+        .mockResolvedValue('有給休暇は年間20日付与されます。');
+      jest.spyOn(service['supabaseService'], 'getClient').mockReturnValue({
+        rpc: mockRpc,
+      } as unknown as ReturnType<typeof service['supabaseService']['getClient']>);
+
+      const result = await service.queryWithScore('有給休暇は何日？');
+
+      expect(result.confidence).toBe('HIGH');
+      expect(result.sources).toHaveLength(2);
+      expect(result.sources[0].confidenceLevel).toBe('HIGH');
+      expect(result.sources[0].documentTitle).toBe('hr-rules');
+      expect(result.warning).toBeNull();
+      expect(result.executionTimeMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('中スコアのソースがある場合はMEDIUM信頼度で返す', async () => {
+      const mockData = [
+        { content: '関連情報です。', similarity: 0.75, metadata: { source: 'doc' } },
+      ];
+      const mockRpc = jest.fn().mockResolvedValue({ data: mockData, error: null });
+
+      jest.spyOn(service as unknown as { generateEmbedding: () => Promise<number[]> }, 'generateEmbedding')
+        .mockResolvedValue(mockEmbedding);
+      jest.spyOn(service as unknown as { generateAnswer: () => Promise<string> }, 'generateAnswer')
+        .mockResolvedValue('回答です。');
+      jest.spyOn(service['supabaseService'], 'getClient').mockReturnValue({
+        rpc: mockRpc,
+      } as unknown as ReturnType<typeof service['supabaseService']['getClient']>);
+
+      const result = await service.queryWithScore('質問です');
+
+      expect(result.confidence).toBe('MEDIUM');
+      expect(result.sources[0].confidenceLevel).toBe('MEDIUM');
+      expect(result.warning).toBeNull();
+    });
+
+    it('ソースが見つからない場合はLOW信頼度と警告を返す', async () => {
+      const mockRpc = jest.fn().mockResolvedValue({ data: [], error: null });
+
+      jest.spyOn(service as unknown as { generateEmbedding: () => Promise<number[]> }, 'generateEmbedding')
+        .mockResolvedValue(mockEmbedding);
+      jest.spyOn(service['supabaseService'], 'getClient').mockReturnValue({
+        rpc: mockRpc,
+      } as unknown as ReturnType<typeof service['supabaseService']['getClient']>);
+
+      const result = await service.queryWithScore('存在しない情報');
+
+      expect(result.confidence).toBe('LOW');
+      expect(result.sources).toHaveLength(0);
+      expect(result.warning).not.toBeNull();
+      expect(result.answer).toBe('関連するドキュメントが見つかりませんでした。');
+    });
+
+    it('RPCエラー時は例外をスローする', async () => {
+      const mockRpc = jest.fn().mockResolvedValue({ data: null, error: { message: 'rpc failed' } });
+
+      jest.spyOn(service as unknown as { generateEmbedding: () => Promise<number[]> }, 'generateEmbedding')
+        .mockResolvedValue(mockEmbedding);
+      jest.spyOn(service['supabaseService'], 'getClient').mockReturnValue({
+        rpc: mockRpc,
+      } as unknown as ReturnType<typeof service['supabaseService']['getClient']>);
+
+      await expect(service.queryWithScore('test')).rejects.toThrow('Supabase RPC error');
+    });
+  });
+
+  describe('deleteAll', () => {
+    it('全件削除して件数を返す', async () => {
+      const mockNeq = jest.fn().mockResolvedValue({ count: 5, error: null });
+      const mockDelete = jest.fn().mockReturnValue({ neq: mockNeq });
+      const mockFrom = jest.fn().mockReturnValue({ delete: mockDelete });
+
+      jest.spyOn(service['supabaseService'], 'getClient').mockReturnValue({
+        from: mockFrom,
+      } as unknown as ReturnType<typeof service['supabaseService']['getClient']>);
+
+      const result = await service.deleteAll();
+
+      expect(result.success).toBe(true);
+      expect(result.deletedCount).toBe(5);
+      expect(result.message).toContain('5件');
+    });
+  });
+});

--- a/src/rag/score-display/views/score-display.html
+++ b/src/rag/score-display/views/score-display.html
@@ -1,0 +1,326 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>根拠スコア表示 - RAGデモ</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      background: linear-gradient(135deg, #1b5e20 0%, #004d40 100%);
+      min-height: 100vh;
+      padding: 20px;
+    }
+
+    .page-header { text-align: center; color: white; margin-bottom: 24px; }
+    .page-header h1 { font-size: 1.8rem; margin-bottom: 6px; }
+    .page-header p { opacity: 0.85; font-size: 0.95rem; }
+
+    .header-links { display: flex; gap: 8px; margin-bottom: 16px; align-items: center; }
+
+    .back-link {
+      display: inline-block; color: white; text-decoration: none;
+      padding: 6px 14px; border: 1px solid white; border-radius: 6px;
+      font-size: 0.85rem; transition: all 0.2s;
+    }
+    .back-link:hover { background: white; color: #1b5e20; }
+
+    .gh-link {
+      display: inline-flex; align-items: center; gap: 5px; color: white;
+      text-decoration: none; padding: 6px 14px; border: 1px solid rgba(255,255,255,0.6);
+      border-radius: 6px; font-size: 0.85rem; opacity: 0.85; transition: all 0.2s;
+    }
+    .gh-link:hover { background: white; color: #1b5e20; opacity: 1; }
+
+    .container { max-width: 800px; margin: 0 auto; }
+
+    .card {
+      background: white; border-radius: 12px;
+      box-shadow: 0 4px 20px rgba(0,0,0,0.12);
+      padding: 20px; margin-bottom: 16px;
+    }
+
+    .card h2 { font-size: 1rem; font-weight: 700; color: #1b5e20; margin-bottom: 14px; }
+
+    label { display: block; font-size: 0.85rem; font-weight: 600; color: #555; margin-bottom: 5px; }
+
+    input[type="text"], input[type="number"], textarea {
+      width: 100%; padding: 10px 12px; border: 2px solid #ddd;
+      border-radius: 8px; font-size: 0.9rem; outline: none;
+      font-family: inherit; transition: border-color 0.2s;
+    }
+    input:focus, textarea:focus { border-color: #1b5e20; }
+    textarea { resize: vertical; min-height: 100px; }
+
+    .form-group { margin-bottom: 12px; }
+    .form-row { display: flex; gap: 10px; }
+    .form-row .form-group { flex: 1; }
+
+    .btn {
+      padding: 10px 22px; border: none; border-radius: 8px;
+      font-size: 0.9rem; font-weight: 600; cursor: pointer; transition: all 0.2s;
+    }
+    .btn-primary { background: #1b5e20; color: white; }
+    .btn-primary:hover { background: #2e7d32; }
+    .btn-primary:disabled { background: #90a4ae; cursor: not-allowed; }
+    .btn-danger { background: #c62828; color: white; font-size: 0.8rem; padding: 6px 14px; }
+    .btn-danger:hover { background: #d32f2f; }
+
+    /* 信頼度バッジ */
+    .badge {
+      display: inline-flex; align-items: center; gap: 5px;
+      padding: 3px 10px; border-radius: 12px; font-size: 0.8rem; font-weight: 700;
+    }
+    .badge-high { background: #e8f5e9; color: #1b5e20; border: 1px solid #a5d6a7; }
+    .badge-medium { background: #fff8e1; color: #f57f17; border: 1px solid #ffe082; }
+    .badge-low { background: #ffebee; color: #b71c1c; border: 1px solid #ef9a9a; }
+
+    /* スコアバー */
+    .score-bar-wrap { display: flex; align-items: center; gap: 8px; margin: 6px 0; }
+    .score-bar-bg {
+      flex: 1; height: 8px; background: #e0e0e0; border-radius: 4px; overflow: hidden;
+    }
+    .score-bar-fill { height: 100%; border-radius: 4px; transition: width 0.4s; }
+    .fill-high { background: #43a047; }
+    .fill-medium { background: #ffb300; }
+    .fill-low { background: #e53935; }
+    .score-pct { font-size: 0.82rem; font-weight: 700; min-width: 36px; text-align: right; }
+
+    /* 全体信頼度 */
+    .overall-confidence {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 16px; border-radius: 10px; margin-bottom: 14px;
+    }
+    .oc-high { background: #e8f5e9; border-left: 4px solid #43a047; }
+    .oc-medium { background: #fff8e1; border-left: 4px solid #ffb300; }
+    .oc-low { background: #ffebee; border-left: 4px solid #e53935; }
+    .oc-label { font-size: 0.82rem; color: #666; }
+    .oc-value { font-size: 1.1rem; font-weight: 700; }
+
+    /* 回答 */
+    .answer-box {
+      padding: 14px; background: #f9fbe7; border-radius: 8px;
+      font-size: 0.92rem; line-height: 1.7; margin-bottom: 14px;
+    }
+
+    /* 警告 */
+    .warning-box {
+      padding: 10px 14px; background: #fff3e0; border-left: 4px solid #ff9800;
+      border-radius: 0 8px 8px 0; font-size: 0.85rem; color: #e65100; margin-bottom: 14px;
+    }
+
+    /* ソース */
+    .source-item {
+      padding: 12px 14px; border: 1px solid #e0e0e0; border-radius: 8px; margin-bottom: 8px;
+    }
+    .source-header { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; }
+    .source-title { font-size: 0.85rem; font-weight: 600; color: #333; flex: 1; }
+    .source-text { font-size: 0.83rem; color: #555; line-height: 1.5; }
+
+    .result-box {
+      margin-top: 14px; padding: 14px; border-radius: 8px; font-size: 0.9rem;
+    }
+    .result-box.success { background: #e8f5e9; border-left: 4px solid #1b5e20; }
+    .result-box.error { background: #ffebee; border-left: 4px solid #e53935; }
+    .result-box.info { background: #e3f2fd; border-left: 4px solid #1565c0; }
+
+    .meta { font-size: 0.8rem; color: #888; margin-top: 10px; }
+    .hidden { display: none; }
+  </style>
+</head>
+<body>
+
+<div class="container">
+  <div class="header-links">
+    <a href="/node" class="back-link">← Back to Home</a>
+    <a href="https://github.com/RYA234/typescript-container/issues/64" class="gh-link" target="_blank">GitHub #64</a>
+  </div>
+
+  <div class="page-header">
+    <h1>根拠スコア表示</h1>
+    <p>RAGの回答に類似度スコアと信頼度レベル（HIGH/MEDIUM/LOW）を付与して可視化する</p>
+  </div>
+
+  <!-- 登録カード（開発環境のみ） -->
+  <div class="card hidden" id="ingestCard">
+    <h2>📥 ドキュメント登録</h2>
+    <div class="form-group">
+      <label>テキスト</label>
+      <textarea id="ingestText" placeholder="例: 有給休暇は年間20日付与されます。勤続1年未満は10日。申請は3日前までに届け出ること。"></textarea>
+    </div>
+    <div class="form-group">
+      <label>ソース名（任意）</label>
+      <input type="text" id="ingestSource" placeholder="例: hr-rules">
+    </div>
+    <div style="display:flex;gap:10px;align-items:center;">
+      <button class="btn btn-primary" id="ingestBtn" onclick="doIngest()">登録</button>
+      <button class="btn btn-danger" onclick="doDeleteAll()">全件削除</button>
+    </div>
+    <div id="ingestResult"></div>
+  </div>
+
+  <!-- クエリカード -->
+  <div class="card">
+    <h2>🔍 スコア付きRAGクエリ</h2>
+    <div class="form-row">
+      <div class="form-group" style="flex:3;">
+        <label>質問</label>
+        <input type="text" id="questionInput" placeholder="例: 有給休暇は何日取れますか？">
+      </div>
+      <div class="form-group" style="flex:1;">
+        <label>しきい値 (0〜1)</label>
+        <input type="number" id="thresholdInput" value="0.3" min="0" max="1" step="0.05">
+      </div>
+    </div>
+    <button class="btn btn-primary" id="queryBtn" onclick="doQuery()">質問する</button>
+    <div id="queryResult"></div>
+  </div>
+</div>
+
+<script>
+  async function checkConfig() {
+    try {
+      const res = await fetch('/node/rag/scored/config');
+      const data = await res.json();
+      if (data.writeEnabled) document.getElementById('ingestCard').classList.remove('hidden');
+    } catch {}
+  }
+  checkConfig();
+
+  function escape(str) {
+    return String(str).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+  }
+
+  function confidenceClass(level) {
+    if (level === 'HIGH') return 'high';
+    if (level === 'MEDIUM') return 'medium';
+    return 'low';
+  }
+
+  function confidenceLabel(level) {
+    if (level === 'HIGH') return '高信頼 (HIGH)';
+    if (level === 'MEDIUM') return '中信頼 (MEDIUM)';
+    return '低信頼 (LOW)';
+  }
+
+  function scoreBar(similarity, level) {
+    const pct = (similarity * 100).toFixed(1);
+    const cls = confidenceClass(level);
+    return `
+      <div class="score-bar-wrap">
+        <div class="score-bar-bg">
+          <div class="score-bar-fill fill-${cls}" style="width:${pct}%"></div>
+        </div>
+        <span class="score-pct" style="color:${cls==='high'?'#2e7d32':cls==='medium'?'#f57f17':'#c62828'}">${pct}%</span>
+      </div>`;
+  }
+
+  async function doIngest() {
+    const text = document.getElementById('ingestText').value.trim();
+    const source = document.getElementById('ingestSource').value.trim() || undefined;
+    const resultEl = document.getElementById('ingestResult');
+    const btn = document.getElementById('ingestBtn');
+    if (!text) { resultEl.innerHTML = '<div class="result-box error">テキストを入力してください</div>'; return; }
+    btn.disabled = true;
+    resultEl.innerHTML = '<div class="result-box info">登録中...</div>';
+    try {
+      const res = await fetch('/node/rag/scored/ingest', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text, source }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        resultEl.innerHTML = `<div class="result-box error">${escape(data.message)}</div>`;
+      } else {
+        resultEl.innerHTML = `<div class="result-box success">✅ 登録完了 ${data.chunkCount}チャンク / ${data.executionTimeMs}ms</div>`;
+        document.getElementById('ingestText').value = '';
+      }
+    } catch {
+      resultEl.innerHTML = '<div class="result-box error">通信エラー</div>';
+    } finally {
+      btn.disabled = false;
+    }
+  }
+
+  async function doDeleteAll() {
+    if (!confirm('すべてのドキュメントを削除しますか？')) return;
+    try {
+      const res = await fetch('/node/rag/scored/documents', { method: 'DELETE' });
+      const data = await res.json();
+      document.getElementById('ingestResult').innerHTML = `<div class="result-box info">${escape(data.message)}</div>`;
+    } catch {
+      alert('削除エラー');
+    }
+  }
+
+  async function doQuery() {
+    const question = document.getElementById('questionInput').value.trim();
+    const threshold = parseFloat(document.getElementById('thresholdInput').value) || 0.3;
+    const resultEl = document.getElementById('queryResult');
+    const btn = document.getElementById('queryBtn');
+    if (!question) { resultEl.innerHTML = '<div class="result-box error">質問を入力してください</div>'; return; }
+
+    btn.disabled = true;
+    resultEl.innerHTML = '<div class="result-box info">検索・回答生成中...</div>';
+
+    try {
+      const res = await fetch('/node/rag/scored/query', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ question, confidenceThreshold: threshold }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        resultEl.innerHTML = `<div class="result-box error">${escape(data.message)}</div>`;
+        return;
+      }
+
+      const cls = confidenceClass(data.confidence);
+      const warningHtml = data.warning
+        ? `<div class="warning-box">⚠️ ${escape(data.warning)}</div>` : '';
+
+      const sourcesHtml = data.sources.length > 0
+        ? data.sources.map((s, i) => `
+            <div class="source-item">
+              <div class="source-header">
+                <span class="badge badge-${confidenceClass(s.confidenceLevel)}">${s.confidenceLevel}</span>
+                <span class="source-title">${escape(s.documentTitle)} チャンク${s.chunkIndex}</span>
+              </div>
+              ${scoreBar(s.similarity, s.confidenceLevel)}
+              <div class="source-text">${escape(s.content.substring(0, 150))}${s.content.length > 150 ? '...' : ''}</div>
+            </div>`).join('')
+        : '<div style="color:#888;font-size:0.88rem;">参照ソースが見つかりませんでした</div>';
+
+      resultEl.innerHTML = `
+        <div style="margin-top:14px;">
+          <div class="overall-confidence oc-${cls}">
+            <div>
+              <div class="oc-label">全体の信頼度</div>
+              <div class="oc-value">${confidenceLabel(data.confidence)}</div>
+            </div>
+            ${scoreBar(data.sources.length > 0 ? Math.max(...data.sources.map(s=>s.similarity)) : 0, data.confidence)}
+          </div>
+          ${warningHtml}
+          <div class="answer-box">${escape(data.answer).replace(/\n/g,'<br>')}</div>
+          <div style="font-size:0.88rem;font-weight:700;color:#1b5e20;margin-bottom:8px;">参照ソース (${data.sources.length}件)</div>
+          ${sourcesHtml}
+          <div class="meta">処理時間: ${data.executionTimeMs}ms</div>
+        </div>`;
+    } catch {
+      resultEl.innerHTML = '<div class="result-box error">通信エラー</div>';
+    } finally {
+      btn.disabled = false;
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    document.getElementById('questionInput').addEventListener('keydown', e => {
+      if (e.key === 'Enter') doQuery();
+    });
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- RAGの検索結果に類似度スコア（0〜1）とHIGH/MEDIUM/LOW信頼度レベルを付与して可視化
- 既存の `documents` テーブルと `match_documents` RPC を再利用（新規DDL不要）
- スコアバー・バッジ・警告ボックスを含むグリーンテーマのUI実装

## 変更ファイル

- `src/interfaces/rag-score-display.ts` — 型定義
- `src/rag/score-display/service.ts` — 信頼度計算・クエリ・削除ロジック
- `src/rag/score-display/controller.ts` — リクエストハンドラ
- `src/rag/score-display/router.ts` — ルーティング（`/node/rag/scored/*`）
- `src/rag/score-display/views/score-display.html` — スコア可視化UI
- `src/rag/score-display/tests/score-display.test.ts` — 7テスト全通過
- `src/rag/router.ts` — `/score` → HTML、`/scored` → router に接続

## 信頼度レベル閾値

| レベル | スコア |
|--------|--------|
| HIGH   | ≥ 0.85 |
| MEDIUM | ≥ 0.70 |
| LOW    | < 0.70 |

## Test plan

- [ ] `npx jest src/rag/score-display/tests/score-display.test.ts` → 7/7 PASS
- [ ] `/node/rag/score` — UIページが表示される
- [ ] `/node/rag/scored/ingest` — ドキュメント登録（開発環境のみ）
- [ ] `/node/rag/scored/query` — 質問でスコア付き回答が返る
- [ ] HIGH/MEDIUM/LOW バッジとスコアバーが正しく表示される

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)